### PR TITLE
Add .gstack/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ playground.xcworkspace
 .env
 .env.*
 !.env.example
+.gstack/


### PR DESCRIPTION
Adds the `.gstack/` directory to `.gitignore` so local gstack artifacts aren't tracked.