### PR TITLE
Add Swift backgammon game engine package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ DerivedData/
 # Swift Package Manager
 .build/
 .swiftpm/
-Packages/
 Package.pins
 Package.resolved
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.1
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "SheshBesh",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "SheshBeshGame",
+            targets: ["SheshBeshGame"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "SheshBeshGame",
+            path: "Packages/SheshBeshGame/Sources/SheshBeshGame",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .testTarget(
+            name: "SheshBeshGameTests",
+            dependencies: ["SheshBeshGame"],
+            path: "Packages/SheshBeshGame/Tests/SheshBeshGameTests",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+    ]
+)

--- a/Packages/SheshBeshGame/Package.swift
+++ b/Packages/SheshBeshGame/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.3
+// swift-tools-version: 6.1
 
 import PackageDescription
 

--- a/Packages/SheshBeshGame/Package.swift
+++ b/Packages/SheshBeshGame/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 6.3
+
+import PackageDescription
+
+let package = Package(
+    name: "SheshBeshGame",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "SheshBeshGame",
+            targets: ["SheshBeshGame"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "SheshBeshGame",
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+        .testTarget(
+            name: "SheshBeshGameTests",
+            dependencies: ["SheshBeshGame"],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+            ]
+        ),
+    ]
+)

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/Board.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/Board.swift
@@ -1,0 +1,210 @@
+public struct PointState: Codable, Equatable, Hashable, Sendable {
+    public let owner: Player?
+    public let count: Int
+
+    public init(owner: Player?, count: Int) {
+        precondition(count >= 0, "Point count cannot be negative")
+        precondition((owner == nil) == (count == 0), "Empty points must not have an owner")
+        self.owner = owner
+        self.count = count
+    }
+
+    public static let empty = PointState(owner: nil, count: 0)
+}
+
+public struct Board: Codable, Equatable, Hashable, Sendable {
+    public private(set) var points: [PointState]
+    public private(set) var whiteBar: Int
+    public private(set) var blackBar: Int
+    public private(set) var whiteBorneOff: Int
+    public private(set) var blackBorneOff: Int
+
+    public init(
+        points: [PointState],
+        whiteBar: Int = 0,
+        blackBar: Int = 0,
+        whiteBorneOff: Int = 0,
+        blackBorneOff: Int = 0
+    ) throws {
+        guard points.count == 24 else { throw BoardError.invalidPointCount }
+        guard whiteBar >= 0, blackBar >= 0, whiteBorneOff >= 0, blackBorneOff >= 0 else {
+            throw BoardError.negativeCheckerCount
+        }
+        self.points = points
+        self.whiteBar = whiteBar
+        self.blackBar = blackBar
+        self.whiteBorneOff = whiteBorneOff
+        self.blackBorneOff = blackBorneOff
+    }
+
+    public static func empty() -> Board {
+        try! Board(points: Array(repeating: .empty, count: 24))
+    }
+
+    public static func initial() -> Board {
+        var board = Board.empty()
+        try! board.setPoint(PointID(rawValue: 24)!, owner: .white, count: 2)
+        try! board.setPoint(PointID(rawValue: 13)!, owner: .white, count: 5)
+        try! board.setPoint(PointID(rawValue: 8)!, owner: .white, count: 3)
+        try! board.setPoint(PointID(rawValue: 6)!, owner: .white, count: 5)
+        try! board.setPoint(PointID(rawValue: 1)!, owner: .black, count: 2)
+        try! board.setPoint(PointID(rawValue: 12)!, owner: .black, count: 5)
+        try! board.setPoint(PointID(rawValue: 17)!, owner: .black, count: 3)
+        try! board.setPoint(PointID(rawValue: 19)!, owner: .black, count: 5)
+        return board
+    }
+
+    public func point(_ id: PointID) -> PointState {
+        points[id.rawValue - 1]
+    }
+
+    public func barCount(for player: Player) -> Int {
+        switch player {
+        case .white: whiteBar
+        case .black: blackBar
+        }
+    }
+
+    public func borneOffCount(for player: Player) -> Int {
+        switch player {
+        case .white: whiteBorneOff
+        case .black: blackBorneOff
+        }
+    }
+
+    public func occupiedPoints(for player: Player) -> [PointID] {
+        points.enumerated().compactMap { index, state in
+            guard state.owner == player, state.count > 0 else { return nil }
+            return PointID(rawValue: index + 1)
+        }
+    }
+
+    public func totalCheckers(for player: Player) -> Int {
+        let onBoard = points.reduce(0) { total, state in
+            total + (state.owner == player ? state.count : 0)
+        }
+        return onBoard + barCount(for: player) + borneOffCount(for: player)
+    }
+
+    public func isValidForGame() -> Bool {
+        guard points.count == 24 else { return false }
+        guard whiteBar >= 0, blackBar >= 0, whiteBorneOff >= 0, blackBorneOff >= 0 else {
+            return false
+        }
+        guard points.allSatisfy({ $0.count >= 0 && (($0.owner == nil) == ($0.count == 0)) }) else {
+            return false
+        }
+        return totalCheckers(for: .white) == 15 && totalCheckers(for: .black) == 15
+    }
+
+    public func allCheckersAreHome(for player: Player) -> Bool {
+        guard barCount(for: player) == 0 else { return false }
+        for point in occupiedPoints(for: player) where !player.isHomePoint(point) {
+            return false
+        }
+        return true
+    }
+
+    public func canLand(on point: PointID, player: Player) -> Bool {
+        let state = self.point(point)
+        return state.owner == nil || state.owner == player || state.count == 1
+    }
+
+    public func hasCheckerOnBarOrInHomeBoard(of winner: Player, loser: Player) -> Bool {
+        if barCount(for: loser) > 0 { return true }
+        return occupiedPoints(for: loser).contains { winner.homeBoard.contains($0.rawValue) }
+    }
+
+    public mutating func setPoint(_ id: PointID, owner: Player?, count: Int) throws {
+        guard count >= 0 else { throw BoardError.negativeCheckerCount }
+        guard (owner == nil) == (count == 0) else { throw BoardError.invalidPointOccupancy }
+        points[id.rawValue - 1] = PointState(owner: owner, count: count)
+    }
+
+    public mutating func setBar(for player: Player, count: Int) throws {
+        guard count >= 0 else { throw BoardError.negativeCheckerCount }
+        switch player {
+        case .white: whiteBar = count
+        case .black: blackBar = count
+        }
+    }
+
+    public mutating func setBorneOff(for player: Player, count: Int) throws {
+        guard count >= 0 else { throw BoardError.negativeCheckerCount }
+        switch player {
+        case .white: whiteBorneOff = count
+        case .black: blackBorneOff = count
+        }
+    }
+
+    internal mutating func apply(_ move: Move) throws {
+        try removeChecker(from: move.source, player: move.player)
+        try addChecker(to: move.destination, player: move.player)
+    }
+
+    internal func canBearOff(player: Player, from point: PointID, die: Int) -> Bool {
+        guard allCheckersAreHome(for: player), player.isHomePoint(point) else { return false }
+
+        switch player {
+        case .white:
+            if point.rawValue == die { return true }
+            guard die > point.rawValue else { return false }
+            let fartherPoints = (point.rawValue + 1)...6
+            return fartherPoints.allSatisfy { rawValue in
+                self.point(PointID(rawValue: rawValue)!).owner != .white
+            }
+        case .black:
+            let exactDie = 25 - point.rawValue
+            if exactDie == die { return true }
+            guard die > exactDie else { return false }
+            let fartherPoints = 19..<(point.rawValue)
+            return fartherPoints.allSatisfy { rawValue in
+                self.point(PointID(rawValue: rawValue)!).owner != .black
+            }
+        }
+    }
+
+    private mutating func removeChecker(from source: MoveSource, player: Player) throws {
+        switch source {
+        case .bar:
+            let count = barCount(for: player)
+            guard count > 0 else { throw BoardError.noCheckerAtSource }
+            try setBar(for: player, count: count - 1)
+        case .point(let point):
+            let state = self.point(point)
+            guard state.owner == player, state.count > 0 else { throw BoardError.noCheckerAtSource }
+            try setPoint(
+                point,
+                owner: state.count == 1 ? nil : player,
+                count: state.count - 1
+            )
+        }
+    }
+
+    private mutating func addChecker(to destination: MoveDestination, player: Player) throws {
+        switch destination {
+        case .off:
+            try setBorneOff(for: player, count: borneOffCount(for: player) + 1)
+        case .point(let point):
+            let state = self.point(point)
+            if state.owner == player {
+                try setPoint(point, owner: player, count: state.count + 1)
+            } else if state.owner == nil {
+                try setPoint(point, owner: player, count: 1)
+            } else if state.count == 1 {
+                try setPoint(point, owner: player, count: 1)
+                try setBar(for: player.opponent, count: barCount(for: player.opponent) + 1)
+            } else {
+                throw BoardError.blockedDestination
+            }
+        }
+    }
+}
+
+public enum BoardError: Error, Equatable, Sendable {
+    case invalidPointCount
+    case negativeCheckerCount
+    case invalidPointOccupancy
+    case noCheckerAtSource
+    case blockedDestination
+}

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/Dice.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/Dice.swift
@@ -1,0 +1,37 @@
+public protocol DiceRolling: Sendable {
+    func rollDie() -> Int
+}
+
+public struct SystemDiceRoller: DiceRolling {
+    public init() {}
+
+    public func rollDie() -> Int {
+        Int.random(in: 1...6)
+    }
+}
+
+public struct DiceRoll: Codable, Equatable, Hashable, Sendable {
+    public let die1: Int
+    public let die2: Int
+
+    public init(die1: Int, die2: Int) throws {
+        guard (1...6).contains(die1), (1...6).contains(die2) else {
+            throw MatchEngineError.invalidDiceValue
+        }
+        self.die1 = die1
+        self.die2 = die2
+    }
+
+    internal init(uncheckedDie1 die1: Int, die2: Int) {
+        self.die1 = die1
+        self.die2 = die2
+    }
+
+    public var isDouble: Bool {
+        die1 == die2
+    }
+
+    public var playableDice: [Int] {
+        isDouble ? Array(repeating: die1, count: 4) : [die1, die2]
+    }
+}

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
@@ -29,6 +29,9 @@ public struct MatchEngine: Sendable {
             return actions
         case .awaitingMove(let turn):
             var actions = MoveValidator.legalFirstMoves(for: turn.player, in: state.game).map(MatchAction.move)
+            if actions.isEmpty {
+                actions.append(.passTurn(turn.player))
+            }
             actions.append(contentsOf: resignationActions(for: turn.player))
             return actions
         case .awaitingCubeResponse(let offer):
@@ -54,6 +57,8 @@ public struct MatchEngine: Sendable {
             return try rollDice(for: player, in: state)
         case .move(let move):
             return try apply(move: move, to: state)
+        case .passTurn(let player):
+            return try passTurn(by: player, in: state)
         case .offerDouble(let player):
             return try offerDouble(by: player, in: state)
         case .takeDouble(let player):
@@ -127,11 +132,21 @@ public struct MatchEngine: Sendable {
         } else {
             let nextTurn = TurnState(player: turn.player, roll: turn.roll, remainingDice: remainingDice)
             next.game.phase = .awaitingMove(nextTurn)
-            if MoveValidator.legalMoves(for: turn.player, in: next.game).isEmpty {
-                next.game.phase = .awaitingRoll(turn.player.opponent)
-            }
         }
 
+        return next
+    }
+
+    private func passTurn(by player: Player, in state: MatchState) throws -> MatchState {
+        guard case .awaitingMove(let turn) = state.game.phase, turn.player == player else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) has no turn to pass.")
+        }
+        guard MoveValidator.legalMoves(for: player, in: state.game).isEmpty else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) still has legal moves.")
+        }
+
+        var next = state
+        next.game.phase = .awaitingRoll(player.opponent)
         return next
     }
 
@@ -246,9 +261,6 @@ public struct MatchEngine: Sendable {
         next.phase = .awaitingMove(
             TurnState(player: player, roll: roll, remainingDice: roll.playableDice)
         )
-        if MoveValidator.legalMoves(for: player, in: next).isEmpty {
-            next.phase = .awaitingRoll(player.opponent)
-        }
         return next
     }
 

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
@@ -1,0 +1,308 @@
+public struct MatchEngine: Sendable {
+    private let diceRoller: any DiceRolling
+
+    public init(diceRoller: any DiceRolling = SystemDiceRoller()) {
+        self.diceRoller = diceRoller
+    }
+
+    public static func newMatch(config: MatchConfig) -> MatchState {
+        MatchState(config: config)
+    }
+
+    public func legalActions(in state: MatchState) -> [MatchAction] {
+        Self.legalActions(in: state)
+    }
+
+    public static func legalActions(in state: MatchState) -> [MatchAction] {
+        guard state.completion == nil else { return [] }
+
+        switch state.game.phase {
+        case .awaitingOpeningRoll:
+            return [.rollOpeningDice]
+        case .awaitingRoll(let player):
+            var actions: [MatchAction] = []
+            if canOfferDouble(player, in: state) {
+                actions.append(.offerDouble(player))
+            }
+            actions.append(.rollDice(player))
+            actions.append(contentsOf: resignationActions(for: player))
+            return actions
+        case .awaitingMove(let turn):
+            var actions = MoveValidator.legalFirstMoves(for: turn.player, in: state.game).map(MatchAction.move)
+            actions.append(contentsOf: resignationActions(for: turn.player))
+            return actions
+        case .awaitingCubeResponse(let offer):
+            let responder = offer.offeredBy.opponent
+            return [.takeDouble(responder), .dropDouble(responder)]
+        case .awaitingResignationResponse(let offer):
+            let responder = offer.offeredBy.opponent
+            return [.acceptResignation(responder), .rejectResignation(responder)]
+        case .gameOver:
+            return [.startNextGame]
+        }
+    }
+
+    public func apply(action: MatchAction, to state: MatchState) throws -> MatchState {
+        guard state.completion == nil || action == .startNextGame else {
+            throw MatchEngineError.matchAlreadyCompleted
+        }
+
+        switch action {
+        case .rollOpeningDice:
+            return try rollOpeningDice(in: state)
+        case .rollDice(let player):
+            return try rollDice(for: player, in: state)
+        case .move(let move):
+            return try apply(move: move, to: state)
+        case .offerDouble(let player):
+            return try offerDouble(by: player, in: state)
+        case .takeDouble(let player):
+            return try takeDouble(by: player, in: state)
+        case .dropDouble(let player):
+            return try dropDouble(by: player, in: state)
+        case .offerResignation(let player, let winKind):
+            return try offerResignation(by: player, as: winKind, in: state)
+        case .acceptResignation(let player):
+            return try acceptResignation(by: player, in: state)
+        case .rejectResignation(let player):
+            return try rejectResignation(by: player, in: state)
+        case .startNextGame:
+            return try startNextGame(after: state)
+        }
+    }
+
+    private func rollOpeningDice(in state: MatchState) throws -> MatchState {
+        guard case .awaitingOpeningRoll = state.game.phase else {
+            throw MatchEngineError.invalidAction("Opening dice can only be rolled at the start of a game.")
+        }
+        let whiteDie = try rollDie()
+        let blackDie = try rollDie()
+        guard whiteDie != blackDie else {
+            return state
+        }
+
+        let player: Player = whiteDie > blackDie ? .white : .black
+        let roll = DiceRoll(uncheckedDie1: whiteDie, die2: blackDie)
+        var next = state
+        next.game = Self.beginTurn(player: player, roll: roll, in: state.game)
+        return next
+    }
+
+    private func rollDice(for player: Player, in state: MatchState) throws -> MatchState {
+        guard case .awaitingRoll(player) = state.game.phase else {
+            throw MatchEngineError.invalidAction("It is not \(player.rawValue)'s turn to roll.")
+        }
+        let roll = DiceRoll(uncheckedDie1: try rollDie(), die2: try rollDie())
+        var next = state
+        next.game = Self.beginTurn(player: player, roll: roll, in: state.game)
+        return next
+    }
+
+    private func apply(move: Move, to state: MatchState) throws -> MatchState {
+        guard case .awaitingMove(let turn) = state.game.phase else {
+            throw MatchEngineError.invalidAction("Moves can only be applied while a turn is awaiting checker movement.")
+        }
+        guard move.player == turn.player else {
+            throw MatchEngineError.illegalMove(move)
+        }
+
+        let legalMoves = MoveValidator.legalFirstMoves(for: turn.player, in: state.game)
+        guard legalMoves.contains(move) else {
+            throw MatchEngineError.illegalMove(move)
+        }
+
+        var next = state
+        try next.game.board.apply(move)
+
+        if next.game.board.borneOffCount(for: move.player) == 15 {
+            return Self.finishGame(winner: move.player, board: next.game.board, in: next)
+        }
+
+        let remainingDice = turn.remainingDice.removingFirst(move.die)
+        if remainingDice.isEmpty {
+            next.game.phase = .awaitingRoll(turn.player.opponent)
+        } else {
+            let nextTurn = TurnState(player: turn.player, roll: turn.roll, remainingDice: remainingDice)
+            next.game.phase = .awaitingMove(nextTurn)
+            if MoveValidator.legalMoves(for: turn.player, in: next.game).isEmpty {
+                next.game.phase = .awaitingRoll(turn.player.opponent)
+            }
+        }
+
+        return next
+    }
+
+    private func offerDouble(by player: Player, in state: MatchState) throws -> MatchState {
+        guard Self.canOfferDouble(player, in: state) else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) cannot offer a double now.")
+        }
+        var next = state
+        let proposedValue = min(state.game.cube.value * 2, state.config.maximumCubeValue)
+        next.game.phase = .awaitingCubeResponse(
+            CubeOffer(
+                offeredBy: player,
+                proposedValue: proposedValue,
+                previousCubeValue: state.game.cube.value
+            )
+        )
+        return next
+    }
+
+    private func takeDouble(by player: Player, in state: MatchState) throws -> MatchState {
+        guard case .awaitingCubeResponse(let offer) = state.game.phase, player == offer.offeredBy.opponent else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) cannot take a double now.")
+        }
+
+        var next = state
+        next.game.cube = state.game.cube.doubled(to: offer.proposedValue, owner: player)
+        next.game.phase = .awaitingRoll(offer.offeredBy)
+        return next
+    }
+
+    private func dropDouble(by player: Player, in state: MatchState) throws -> MatchState {
+        guard case .awaitingCubeResponse(let offer) = state.game.phase, player == offer.offeredBy.opponent else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) cannot drop a double now.")
+        }
+
+        let result = GameResult(
+            winner: offer.offeredBy,
+            winKind: .single,
+            cubeValue: offer.previousCubeValue
+        )
+        return Self.finishGame(with: result, in: state)
+    }
+
+    private func offerResignation(by player: Player, as winKind: WinKind, in state: MatchState) throws -> MatchState {
+        let resumePhase: ResumablePhase
+        switch state.game.phase {
+        case .awaitingRoll(player):
+            resumePhase = .awaitingRoll(player)
+        case .awaitingMove(let turn) where turn.player == player:
+            resumePhase = .awaitingMove(turn)
+        default:
+            throw MatchEngineError.invalidAction("\(player.rawValue) cannot resign now.")
+        }
+
+        var next = state
+        next.game.phase = .awaitingResignationResponse(
+            ResignationOffer(offeredBy: player, winKind: winKind, resumePhase: resumePhase)
+        )
+        return next
+    }
+
+    private func acceptResignation(by player: Player, in state: MatchState) throws -> MatchState {
+        guard case .awaitingResignationResponse(let offer) = state.game.phase, player == offer.offeredBy.opponent else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) cannot accept a resignation now.")
+        }
+        let result = GameResult(
+            winner: player,
+            winKind: offer.winKind,
+            cubeValue: state.game.cube.value
+        )
+        return Self.finishGame(with: result, in: state)
+    }
+
+    private func rejectResignation(by player: Player, in state: MatchState) throws -> MatchState {
+        guard case .awaitingResignationResponse(let offer) = state.game.phase, player == offer.offeredBy.opponent else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) cannot reject a resignation now.")
+        }
+        var next = state
+        next.game.phase = offer.resumePhase.gamePhase
+        return next
+    }
+
+    private func startNextGame(after state: MatchState) throws -> MatchState {
+        guard state.completion == nil else {
+            throw MatchEngineError.matchAlreadyCompleted
+        }
+        guard case .gameOver = state.game.phase else {
+            throw MatchEngineError.invalidAction("A new game can only start after the current game is over.")
+        }
+
+        var next = state
+        next.gameNumber += 1
+        let isCrawford = next.config.usesCrawfordRule && next.crawfordState == .availableNextGame
+        next.crawfordState = isCrawford ? .active : next.crawfordState
+        next.game = GameState(
+            board: .initial(),
+            phase: .awaitingOpeningRoll,
+            cube: CubeState(),
+            isCrawford: isCrawford
+        )
+        return next
+    }
+
+    private func rollDie() throws -> Int {
+        let die = diceRoller.rollDie()
+        guard (1...6).contains(die) else { throw MatchEngineError.invalidDiceValue }
+        return die
+    }
+
+    private static func beginTurn(player: Player, roll: DiceRoll, in game: GameState) -> GameState {
+        var next = game
+        next.phase = .awaitingMove(
+            TurnState(player: player, roll: roll, remainingDice: roll.playableDice)
+        )
+        if MoveValidator.legalMoves(for: player, in: next).isEmpty {
+            next.phase = .awaitingRoll(player.opponent)
+        }
+        return next
+    }
+
+    private static func finishGame(winner: Player, board: Board, in state: MatchState) -> MatchState {
+        let loser = winner.opponent
+        let winKind: WinKind
+        if board.borneOffCount(for: loser) > 0 {
+            winKind = .single
+        } else if board.hasCheckerOnBarOrInHomeBoard(of: winner, loser: loser) {
+            winKind = .backgammon
+        } else {
+            winKind = .gammon
+        }
+        let result = GameResult(winner: winner, winKind: winKind, cubeValue: state.game.cube.value)
+        return finishGame(with: result, in: state)
+    }
+
+    private static func finishGame(with result: GameResult, in state: MatchState) -> MatchState {
+        var next = state
+        next.game.phase = .gameOver(result)
+        next.score.add(result.points, to: result.winner)
+
+        if next.score.score(for: result.winner) >= next.config.targetScore {
+            next.completion = MatchCompletion(winner: result.winner, finalScore: next.score)
+            return next
+        }
+
+        if next.crawfordState == .active {
+            next.crawfordState = .completed
+        } else if next.config.usesCrawfordRule,
+                  next.crawfordState == .notReached,
+                  Player.allCases.contains(where: { next.score.score(for: $0) == next.config.targetScore - 1 }) {
+            next.crawfordState = .availableNextGame
+        }
+
+        return next
+    }
+
+    private static func canOfferDouble(_ player: Player, in state: MatchState) -> Bool {
+        guard state.config.usesDoublingCube else { return false }
+        guard !state.game.isCrawford else { return false }
+        guard case .awaitingRoll(player) = state.game.phase else { return false }
+        guard state.game.cube.value < state.config.maximumCubeValue else { return false }
+        return state.game.cube.owner == nil || state.game.cube.owner == player
+    }
+
+    private static func resignationActions(for player: Player) -> [MatchAction] {
+        WinKind.allCases.map { .offerResignation(player, $0) }
+    }
+}
+
+private extension Array where Element == Int {
+    func removingFirst(_ value: Int) -> [Int] {
+        var copy = self
+        if let index = copy.firstIndex(of: value) {
+            copy.remove(at: index)
+        }
+        return copy
+    }
+}

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
@@ -78,7 +78,10 @@ public struct MatchEngine: Sendable {
         let whiteDie = try rollDie()
         let blackDie = try rollDie()
         guard whiteDie != blackDie else {
-            return state
+            let tiedRoll = DiceRoll(uncheckedDie1: whiteDie, die2: blackDie)
+            var next = state
+            next.game.phase = .awaitingOpeningRoll(tiedRoll: tiedRoll)
+            return next
         }
 
         let player: Player = whiteDie > blackDie ? .white : .black
@@ -225,7 +228,7 @@ public struct MatchEngine: Sendable {
         next.crawfordState = isCrawford ? .active : next.crawfordState
         next.game = GameState(
             board: .initial(),
-            phase: .awaitingOpeningRoll,
+            phase: .awaitingOpeningRoll(),
             cube: CubeState(),
             isCrawford: isCrawford
         )

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MoveValidator.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MoveValidator.swift
@@ -1,0 +1,161 @@
+public enum MoveValidator {
+    public static func legalMoves(for player: Player, in game: GameState) -> [MoveSequence] {
+        guard case .awaitingMove(let turn) = game.phase, turn.player == player else {
+            return []
+        }
+        return legalMoves(for: player, board: game.board, dice: turn.remainingDice)
+    }
+
+    public static func legalMoves(for player: Player, board: Board, dice: [Int]) -> [MoveSequence] {
+        let validDice = dice.filter { (1...6).contains($0) }
+        guard !validDice.isEmpty else { return [] }
+
+        let rawSequences = generateSequences(
+            player: player,
+            board: board,
+            dice: validDice
+        )
+        let nonEmptySequences = rawSequences.filter { !$0.moves.isEmpty }
+        guard let maxMoveCount = nonEmptySequences.map(\.moves.count).max() else {
+            return []
+        }
+
+        var sequences = nonEmptySequences.filter { $0.moves.count == maxMoveCount }
+        if shouldApplyHigherDieRule(originalDice: validDice, maxMoveCount: maxMoveCount) {
+            let higherDie = validDice.max()!
+            let higherDieSequences = sequences.filter { $0.moves.first?.die == higherDie }
+            if !higherDieSequences.isEmpty {
+                sequences = higherDieSequences
+            }
+        }
+
+        return uniqueSorted(sequences)
+    }
+
+    public static func legalFirstMoves(for player: Player, in game: GameState) -> [Move] {
+        uniqueSortedMoves(legalMoves(for: player, in: game).compactMap(\.moves.first))
+    }
+
+    public static func legalFirstMoves(for player: Player, board: Board, dice: [Int]) -> [Move] {
+        uniqueSortedMoves(legalMoves(for: player, board: board, dice: dice).compactMap(\.moves.first))
+    }
+
+    private static func generateSequences(
+        player: Player,
+        board: Board,
+        dice: [Int]
+    ) -> [MoveSequence] {
+        let moves = legalSingleMoves(player: player, board: board, dice: dice)
+        guard !moves.isEmpty else {
+            return [MoveSequence(moves: [])]
+        }
+
+        var sequences: [MoveSequence] = []
+        for move in moves {
+            var nextBoard = board
+            do {
+                try nextBoard.apply(move)
+            } catch {
+                continue
+            }
+            let remainingDice = dice.removingFirst(move.die)
+            let tails = generateSequences(player: player, board: nextBoard, dice: remainingDice)
+            for tail in tails {
+                sequences.append(MoveSequence(moves: [move] + tail.moves))
+            }
+        }
+        return sequences
+    }
+
+    private static func legalSingleMoves(player: Player, board: Board, dice: [Int]) -> [Move] {
+        let uniqueDice = Array(Set(dice)).sorted()
+        let sources: [MoveSource]
+        if board.barCount(for: player) > 0 {
+            sources = [.bar]
+        } else {
+            sources = board.occupiedPoints(for: player).map { .point($0) }
+        }
+
+        var moves: [Move] = []
+        for die in uniqueDice {
+            for source in sources {
+                guard let destination = destination(for: source, player: player, die: die, board: board) else {
+                    continue
+                }
+                if case .point(let point) = destination, !board.canLand(on: point, player: player) {
+                    continue
+                }
+                moves.append(Move(player: player, source: source, destination: destination, die: die))
+            }
+        }
+
+        return uniqueSortedMoves(moves)
+    }
+
+    private static func destination(
+        for source: MoveSource,
+        player: Player,
+        die: Int,
+        board: Board
+    ) -> MoveDestination? {
+        switch source {
+        case .bar:
+            guard let entryPoint = player.entryPoint(for: die) else { return nil }
+            return .point(entryPoint)
+        case .point(let point):
+            let destinationRawValue = point.rawValue + (player.movementDirection * die)
+            if let destinationPoint = PointID(rawValue: destinationRawValue) {
+                return .point(destinationPoint)
+            }
+            return board.canBearOff(player: player, from: point, die: die) ? .off : nil
+        }
+    }
+
+    private static func shouldApplyHigherDieRule(originalDice: [Int], maxMoveCount: Int) -> Bool {
+        originalDice.count == 2 && Set(originalDice).count == 2 && maxMoveCount == 1
+    }
+
+    private static func uniqueSorted(_ sequences: [MoveSequence]) -> [MoveSequence] {
+        Array(Set(sequences)).sorted { sequenceSortKey($0) < sequenceSortKey($1) }
+    }
+
+    private static func uniqueSortedMoves(_ moves: [Move]) -> [Move] {
+        Array(Set(moves)).sorted { moveSortKey($0) < moveSortKey($1) }
+    }
+
+    private static func sequenceSortKey(_ sequence: MoveSequence) -> String {
+        sequence.moves.map(moveSortKey).joined(separator: "|")
+    }
+
+    private static func moveSortKey(_ move: Move) -> String {
+        "\(move.player.rawValue):\(move.die):\(sourceSortKey(move.source)):\(destinationSortKey(move.destination))"
+    }
+
+    private static func sourceSortKey(_ source: MoveSource) -> String {
+        switch source {
+        case .bar: "00-bar"
+        case .point(let point): "\(padded(point.rawValue))-point"
+        }
+    }
+
+    private static func destinationSortKey(_ destination: MoveDestination) -> String {
+        switch destination {
+        case .off: "99-off"
+        case .point(let point): "\(padded(point.rawValue))-point"
+        }
+    }
+
+    private static func padded(_ rawValue: Int) -> String {
+        rawValue < 10 ? "0\(rawValue)" : "\(rawValue)"
+    }
+}
+
+private extension Array where Element == Int {
+    func removingFirst(_ value: Int) -> [Int] {
+        var copy = self
+        if let index = copy.firstIndex(of: value) {
+            copy.remove(at: index)
+        }
+        return copy
+    }
+}

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/Moves.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/Moves.swift
@@ -1,0 +1,36 @@
+public enum MoveSource: Codable, Equatable, Hashable, Sendable {
+    case bar
+    case point(PointID)
+}
+
+public enum MoveDestination: Codable, Equatable, Hashable, Sendable {
+    case point(PointID)
+    case off
+}
+
+public struct Move: Codable, Equatable, Hashable, Sendable {
+    public let player: Player
+    public let source: MoveSource
+    public let destination: MoveDestination
+    public let die: Int
+
+    public init(
+        player: Player,
+        source: MoveSource,
+        destination: MoveDestination,
+        die: Int
+    ) {
+        self.player = player
+        self.source = source
+        self.destination = destination
+        self.die = die
+    }
+}
+
+public struct MoveSequence: Codable, Equatable, Hashable, Sendable {
+    public let moves: [Move]
+
+    public init(moves: [Move]) {
+        self.moves = moves
+    }
+}

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/Player.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/Player.swift
@@ -1,0 +1,51 @@
+public enum Player: String, CaseIterable, Codable, Equatable, Hashable, Sendable {
+    case white
+    case black
+
+    public var opponent: Player {
+        switch self {
+        case .white: .black
+        case .black: .white
+        }
+    }
+
+    public var movementDirection: Int {
+        switch self {
+        case .white: -1
+        case .black: 1
+        }
+    }
+
+    public var homeBoard: ClosedRange<Int> {
+        switch self {
+        case .white: 1...6
+        case .black: 19...24
+        }
+    }
+
+    public func entryPoint(for die: Int) -> PointID? {
+        switch self {
+        case .white:
+            PointID(rawValue: 25 - die)
+        case .black:
+            PointID(rawValue: die)
+        }
+    }
+
+    public func isHomePoint(_ point: PointID) -> Bool {
+        homeBoard.contains(point.rawValue)
+    }
+}
+
+public struct PointID: RawRepresentable, Codable, Comparable, Equatable, Hashable, Sendable {
+    public let rawValue: Int
+
+    public init?(rawValue: Int) {
+        guard (1...24).contains(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public static func < (lhs: PointID, rhs: PointID) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
@@ -215,6 +215,7 @@ public enum MatchAction: Codable, Equatable, Hashable, Sendable {
     case rollOpeningDice
     case rollDice(Player)
     case move(Move)
+    case passTurn(Player)
     case offerDouble(Player)
     case takeDouble(Player)
     case dropDouble(Player)

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
@@ -152,7 +152,7 @@ public struct ResignationOffer: Codable, Equatable, Hashable, Sendable {
 }
 
 public enum GamePhase: Codable, Equatable, Hashable, Sendable {
-    case awaitingOpeningRoll
+    case awaitingOpeningRoll(tiedRoll: DiceRoll? = nil)
     case awaitingRoll(Player)
     case awaitingMove(TurnState)
     case awaitingCubeResponse(CubeOffer)
@@ -175,7 +175,7 @@ public struct GameState: Codable, Equatable, Hashable, Sendable {
 
     public init(
         board: Board = .initial(),
-        phase: GamePhase = .awaitingOpeningRoll,
+        phase: GamePhase = .awaitingOpeningRoll(),
         cube: CubeState = CubeState(),
         isCrawford: Bool = false
     ) {

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
@@ -1,0 +1,232 @@
+public struct MatchConfig: Codable, Equatable, Hashable, Sendable {
+    public let targetScore: Int
+    public let maximumCubeValue: Int
+    public let usesDoublingCube: Bool
+    public let usesCrawfordRule: Bool
+
+    public init(
+        targetScore: Int,
+        maximumCubeValue: Int = 64,
+        usesDoublingCube: Bool = true,
+        usesCrawfordRule: Bool = true
+    ) {
+        precondition(targetScore > 0, "Match target score must be positive")
+        precondition(maximumCubeValue > 0, "Maximum cube value must be positive")
+        self.targetScore = targetScore
+        self.maximumCubeValue = maximumCubeValue
+        self.usesDoublingCube = usesDoublingCube
+        self.usesCrawfordRule = usesCrawfordRule
+    }
+
+    public static func tournament(targetScore: Int) -> MatchConfig {
+        MatchConfig(targetScore: targetScore)
+    }
+}
+
+public struct MatchScore: Codable, Equatable, Hashable, Sendable {
+    public private(set) var white: Int
+    public private(set) var black: Int
+
+    public init(white: Int = 0, black: Int = 0) {
+        precondition(white >= 0 && black >= 0, "Scores cannot be negative")
+        self.white = white
+        self.black = black
+    }
+
+    public func score(for player: Player) -> Int {
+        switch player {
+        case .white: white
+        case .black: black
+        }
+    }
+
+    internal mutating func add(_ points: Int, to player: Player) {
+        switch player {
+        case .white: white += points
+        case .black: black += points
+        }
+    }
+}
+
+public struct CubeState: Codable, Equatable, Hashable, Sendable {
+    public let value: Int
+    public let owner: Player?
+
+    public init(value: Int = 1, owner: Player? = nil) {
+        precondition(value > 0, "Cube value must be positive")
+        self.value = value
+        self.owner = owner
+    }
+
+    internal func doubled(to proposedValue: Int, owner newOwner: Player) -> CubeState {
+        CubeState(value: proposedValue, owner: newOwner)
+    }
+}
+
+public enum WinKind: String, CaseIterable, Codable, Equatable, Hashable, Sendable {
+    case single
+    case gammon
+    case backgammon
+
+    public var multiplier: Int {
+        switch self {
+        case .single: 1
+        case .gammon: 2
+        case .backgammon: 3
+        }
+    }
+}
+
+public struct GameResult: Codable, Equatable, Hashable, Sendable {
+    public let winner: Player
+    public let winKind: WinKind
+    public let cubeValue: Int
+    public let points: Int
+
+    public init(winner: Player, winKind: WinKind, cubeValue: Int) {
+        self.winner = winner
+        self.winKind = winKind
+        self.cubeValue = cubeValue
+        self.points = cubeValue * winKind.multiplier
+    }
+}
+
+public struct MatchCompletion: Codable, Equatable, Hashable, Sendable {
+    public let winner: Player
+    public let finalScore: MatchScore
+
+    public init(winner: Player, finalScore: MatchScore) {
+        self.winner = winner
+        self.finalScore = finalScore
+    }
+}
+
+public struct TurnState: Codable, Equatable, Hashable, Sendable {
+    public let player: Player
+    public let roll: DiceRoll
+    public let remainingDice: [Int]
+
+    public init(player: Player, roll: DiceRoll, remainingDice: [Int]) {
+        self.player = player
+        self.roll = roll
+        self.remainingDice = remainingDice
+    }
+}
+
+public struct CubeOffer: Codable, Equatable, Hashable, Sendable {
+    public let offeredBy: Player
+    public let proposedValue: Int
+    public let previousCubeValue: Int
+
+    public init(offeredBy: Player, proposedValue: Int, previousCubeValue: Int) {
+        self.offeredBy = offeredBy
+        self.proposedValue = proposedValue
+        self.previousCubeValue = previousCubeValue
+    }
+}
+
+public enum ResumablePhase: Codable, Equatable, Hashable, Sendable {
+    case awaitingRoll(Player)
+    case awaitingMove(TurnState)
+
+    internal var gamePhase: GamePhase {
+        switch self {
+        case .awaitingRoll(let player):
+            .awaitingRoll(player)
+        case .awaitingMove(let turn):
+            .awaitingMove(turn)
+        }
+    }
+}
+
+public struct ResignationOffer: Codable, Equatable, Hashable, Sendable {
+    public let offeredBy: Player
+    public let winKind: WinKind
+    public let resumePhase: ResumablePhase
+
+    public init(offeredBy: Player, winKind: WinKind, resumePhase: ResumablePhase) {
+        self.offeredBy = offeredBy
+        self.winKind = winKind
+        self.resumePhase = resumePhase
+    }
+}
+
+public enum GamePhase: Codable, Equatable, Hashable, Sendable {
+    case awaitingOpeningRoll
+    case awaitingRoll(Player)
+    case awaitingMove(TurnState)
+    case awaitingCubeResponse(CubeOffer)
+    case awaitingResignationResponse(ResignationOffer)
+    case gameOver(GameResult)
+}
+
+public enum CrawfordState: String, Codable, Equatable, Hashable, Sendable {
+    case notReached
+    case availableNextGame
+    case active
+    case completed
+}
+
+public struct GameState: Codable, Equatable, Hashable, Sendable {
+    public var board: Board
+    public var phase: GamePhase
+    public var cube: CubeState
+    public var isCrawford: Bool
+
+    public init(
+        board: Board = .initial(),
+        phase: GamePhase = .awaitingOpeningRoll,
+        cube: CubeState = CubeState(),
+        isCrawford: Bool = false
+    ) {
+        self.board = board
+        self.phase = phase
+        self.cube = cube
+        self.isCrawford = isCrawford
+    }
+}
+
+public struct MatchState: Codable, Equatable, Hashable, Sendable {
+    public var config: MatchConfig
+    public var score: MatchScore
+    public var game: GameState
+    public var gameNumber: Int
+    public var crawfordState: CrawfordState
+    public var completion: MatchCompletion?
+
+    public init(
+        config: MatchConfig,
+        score: MatchScore = MatchScore(),
+        game: GameState = GameState(),
+        gameNumber: Int = 1,
+        crawfordState: CrawfordState = .notReached,
+        completion: MatchCompletion? = nil
+    ) {
+        self.config = config
+        self.score = score
+        self.game = game
+        self.gameNumber = gameNumber
+        self.crawfordState = crawfordState
+        self.completion = completion
+    }
+}
+
+public enum MatchAction: Codable, Equatable, Hashable, Sendable {
+    case rollOpeningDice
+    case rollDice(Player)
+    case move(Move)
+    case offerDouble(Player)
+    case takeDouble(Player)
+    case dropDouble(Player)
+    case offerResignation(Player, WinKind)
+    case acceptResignation(Player)
+    case rejectResignation(Player)
+    case startNextGame
+}
+
+public enum MatchEngineError: Error, Equatable, Sendable {
+    case invalidDiceValue
+    case invalidAction(String)
+    case illegalMove(Move)
+    case matchAlreadyCompleted
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardInternalTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardInternalTests.swift
@@ -1,0 +1,27 @@
+@testable import SheshBeshGame
+import Testing
+
+@Suite("Board internal mutations")
+struct BoardInternalTests {
+    @Test("Applying a move rejects missing source checkers")
+    func applyRejectsNoCheckerAtSource() {
+        var board = Board.empty()
+        let move = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        expectBoardError(.noCheckerAtSource) {
+            try board.apply(move)
+        }
+    }
+
+    @Test("Applying a move rejects blocked destinations")
+    func applyRejectsBlockedDestination() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setPoint(point(5), owner: .black, count: 2)
+        let move = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        expectBoardError(.blockedDestination) {
+            try board.apply(move)
+        }
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -1,8 +1,16 @@
+import Foundation
 import SheshBeshGame
 import Testing
 
 @Suite("Board")
 struct BoardTests {
+    @Test("Point IDs reject values outside the board")
+    func pointIDRejectsOutOfRangeRawValues() {
+        #expect(PointID(rawValue: 0) == nil)
+        #expect(PointID(rawValue: 25) == nil)
+        #expect(PointID(rawValue: -1) == nil)
+    }
+
     @Test("Initial board has standard checker placement")
     func initialBoardPlacement() {
         let board = Board.initial()
@@ -87,15 +95,60 @@ struct BoardTests {
             _ = try Board(points: points, blackBorneOff: -1)
         }
     }
-}
 
-private func expectBoardError(_ expected: BoardError, _ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected \(expected)")
-    } catch let error as BoardError {
-        #expect(error == expected)
-    } catch {
-        Issue.record("Expected \(expected), got \(error)")
+    @Test("Set point rejects mismatched owner and count")
+    func setPointRejectsInvalidOccupancy() throws {
+        var board = Board.empty()
+
+        expectBoardError(.invalidPointOccupancy) {
+            try board.setPoint(point(1), owner: nil, count: 1)
+        }
+        expectBoardError(.invalidPointOccupancy) {
+            try board.setPoint(point(1), owner: .white, count: 0)
+        }
+    }
+
+    @Test("Game validity rejects malformed checker totals")
+    func isValidForGameRejectsWrongTotals() throws {
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 14)
+        try board.setPoint(point(24), owner: .black, count: 15)
+
+        #expect(!board.isValidForGame())
+    }
+
+    @Test("Game validity rejects malformed point ownership")
+    func isValidForGameRejectsInvalidPointOccupancy() throws {
+        let pointsJSON = ([#"{"owner":"white","count":0}"#] + Array(repeating: #"{"count":0}"#, count: 23))
+            .joined(separator: ",")
+        let json = """
+        {
+          "points": [\(pointsJSON)],
+          "whiteBar": 0,
+          "blackBar": 0,
+          "whiteBorneOff": 15,
+          "blackBorneOff": 15
+        }
+        """
+        let board = try JSONDecoder().decode(Board.self, from: Data(json.utf8))
+
+        #expect(!board.isValidForGame())
+    }
+
+    @Test("Game validity rejects negative decoded counts")
+    func isValidForGameRejectsNegativeCounts() throws {
+        let pointsJSON = Array(repeating: #"{"count":0}"#, count: 24).joined(separator: ",")
+        let json = """
+        {
+          "points": [\(pointsJSON)],
+          "whiteBar": -1,
+          "blackBar": 0,
+          "whiteBorneOff": 15,
+          "blackBorneOff": 15
+        }
+        """
+        let board = try JSONDecoder().decode(Board.self, from: Data(json.utf8))
+
+        #expect(!board.isValidForGame())
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -39,4 +39,24 @@ struct BoardTests {
         #expect(board.barCount(for: .white) == 1)
         #expect(board.totalCheckers(for: .white) == 15)
     }
+
+    @Test("Hitting from the bar preserves both players' total checker counts")
+    func totalsRemainFifteenAfterBarHit() throws {
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(22), owner: .black, count: 1)
+        try board.setBorneOff(for: .black, count: 14)
+
+        let state = try makeMatch(board: board, player: .white, dice: [3])
+        let move = Move(player: .white, source: .bar, destination: .point(point(22)), die: 3)
+        let next = try MatchEngine().apply(action: .move(move), to: state)
+        board = next.game.board
+
+        #expect(board.point(point(22)) == PointState(owner: .white, count: 1))
+        #expect(board.barCount(for: .white) == 0)
+        #expect(board.barCount(for: .black) == 1)
+        #expect(board.totalCheckers(for: .white) == 15)
+        #expect(board.totalCheckers(for: .black) == 15)
+    }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -59,4 +59,43 @@ struct BoardTests {
         #expect(board.totalCheckers(for: .white) == 15)
         #expect(board.totalCheckers(for: .black) == 15)
     }
+
+    @Test("Board initializer rejects invalid point counts")
+    func initializerRejectsInvalidPointCounts() {
+        expectBoardError(.invalidPointCount) {
+            _ = try Board(points: Array(repeating: .empty, count: 23))
+        }
+        expectBoardError(.invalidPointCount) {
+            _ = try Board(points: Array(repeating: .empty, count: 25))
+        }
+    }
+
+    @Test("Board initializer rejects negative checker counts")
+    func initializerRejectsNegativeCheckerCounts() {
+        let points = Array(repeating: PointState.empty, count: 24)
+
+        expectBoardError(.negativeCheckerCount) {
+            _ = try Board(points: points, whiteBar: -1)
+        }
+        expectBoardError(.negativeCheckerCount) {
+            _ = try Board(points: points, blackBar: -1)
+        }
+        expectBoardError(.negativeCheckerCount) {
+            _ = try Board(points: points, whiteBorneOff: -1)
+        }
+        expectBoardError(.negativeCheckerCount) {
+            _ = try Board(points: points, blackBorneOff: -1)
+        }
+    }
+}
+
+private func expectBoardError(_ expected: BoardError, _ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected \(expected)")
+    } catch let error as BoardError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Expected \(expected), got \(error)")
+    }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -1,0 +1,42 @@
+import SheshBeshGame
+import Testing
+
+@Suite("Board")
+struct BoardTests {
+    @Test("Initial board has standard checker placement")
+    func initialBoardPlacement() {
+        let board = Board.initial()
+
+        #expect(board.point(point(24)) == PointState(owner: .white, count: 2))
+        #expect(board.point(point(13)) == PointState(owner: .white, count: 5))
+        #expect(board.point(point(8)) == PointState(owner: .white, count: 3))
+        #expect(board.point(point(6)) == PointState(owner: .white, count: 5))
+
+        #expect(board.point(point(1)) == PointState(owner: .black, count: 2))
+        #expect(board.point(point(12)) == PointState(owner: .black, count: 5))
+        #expect(board.point(point(17)) == PointState(owner: .black, count: 3))
+        #expect(board.point(point(19)) == PointState(owner: .black, count: 5))
+
+        #expect(board.totalCheckers(for: .white) == 15)
+        #expect(board.totalCheckers(for: .black) == 15)
+        #expect(board.isValidForGame())
+    }
+
+    @Test("Board tracks bar, borne off, and home-board status")
+    func barBorneOffAndHomeStatus() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 5)
+        try board.setPoint(point(3), owner: .white, count: 2)
+        try board.setBorneOff(for: .white, count: 8)
+
+        #expect(board.allCheckersAreHome(for: .white))
+        #expect(board.totalCheckers(for: .white) == 15)
+
+        try board.setBar(for: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 7)
+
+        #expect(!board.allCheckersAreHome(for: .white))
+        #expect(board.barCount(for: .white) == 1)
+        #expect(board.totalCheckers(for: .white) == 15)
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
@@ -11,6 +11,10 @@ struct InvariantTests {
         ]
         let engine = MatchEngine(diceRoller: ScriptedDiceRoller(dice))
         var state = MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        var offeredDouble = false
+        var handledCubeResponse = false
+        var offeredResignation = false
+        var handledResignationResponse = false
 
         for _ in 0..<80 {
             let action: MatchAction
@@ -18,13 +22,25 @@ struct InvariantTests {
             case .awaitingOpeningRoll:
                 action = .rollOpeningDice
             case .awaitingRoll(let player):
-                action = .rollDice(player)
+                if !offeredDouble, MatchEngine.legalActions(in: state).contains(.offerDouble(player)) {
+                    offeredDouble = true
+                    action = .offerDouble(player)
+                } else {
+                    action = .rollDice(player)
+                }
             case .awaitingMove(let turn):
-                let firstMove = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: state.game).first)
-                action = .move(firstMove)
+                if !offeredResignation {
+                    offeredResignation = true
+                    action = .offerResignation(turn.player, .single)
+                } else {
+                    let firstMove = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: state.game).first)
+                    action = .move(firstMove)
+                }
             case .awaitingCubeResponse(let offer):
+                handledCubeResponse = true
                 action = .takeDouble(offer.offeredBy.opponent)
             case .awaitingResignationResponse(let offer):
+                handledResignationResponse = true
                 action = .rejectResignation(offer.offeredBy.opponent)
             case .gameOver:
                 if state.completion != nil { return }
@@ -39,5 +55,10 @@ struct InvariantTests {
             #expect(state.score.score(for: .white) >= 0)
             #expect(state.score.score(for: .black) >= 0)
         }
+
+        #expect(offeredDouble)
+        #expect(handledCubeResponse)
+        #expect(offeredResignation)
+        #expect(handledResignationResponse)
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
@@ -33,8 +33,14 @@ struct InvariantTests {
                     offeredResignation = true
                     action = .offerResignation(turn.player, .single)
                 } else {
-                    let firstMove = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: state.game).first)
-                    action = .move(firstMove)
+                    let legalActions = MatchEngine.legalActions(in: state)
+                    if let moveAction = legalActions.first(where: {
+                        if case .move = $0 { true } else { false }
+                    }) {
+                        action = moveAction
+                    } else {
+                        action = try #require(legalActions.first { $0 == .passTurn(turn.player) })
+                    }
                 }
             case .awaitingCubeResponse(let offer):
                 handledCubeResponse = true

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
@@ -1,0 +1,43 @@
+import SheshBeshGame
+import Testing
+
+@Suite("Invariants")
+struct InvariantTests {
+    @Test("Generated legal transitions preserve board invariants")
+    func generatedLegalTransitionsPreserveInvariants() throws {
+        let dice = [
+            6, 1, 3, 2, 5, 4, 2, 2, 6, 3, 1, 5, 4, 4, 2, 1,
+            6, 5, 3, 3, 1, 4, 5, 2, 6, 6, 1, 3, 4, 2, 5, 1,
+        ]
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller(dice))
+        var state = MatchEngine.newMatch(config: .tournament(targetScore: 7))
+
+        for _ in 0..<80 {
+            let action: MatchAction
+            switch state.game.phase {
+            case .awaitingOpeningRoll:
+                action = .rollOpeningDice
+            case .awaitingRoll(let player):
+                action = .rollDice(player)
+            case .awaitingMove(let turn):
+                let firstMove = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: state.game).first)
+                action = .move(firstMove)
+            case .awaitingCubeResponse(let offer):
+                action = .takeDouble(offer.offeredBy.opponent)
+            case .awaitingResignationResponse(let offer):
+                action = .rejectResignation(offer.offeredBy.opponent)
+            case .gameOver:
+                if state.completion != nil { return }
+                action = .startNextGame
+            }
+
+            state = try engine.apply(action: action, to: state)
+
+            #expect(state.game.board.totalCheckers(for: .white) == 15)
+            #expect(state.game.board.totalCheckers(for: .black) == 15)
+            expectNoMixedPoints(state.game.board)
+            #expect(state.score.score(for: .white) >= 0)
+            #expect(state.score.score(for: .black) >= 0)
+        }
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
@@ -1,0 +1,241 @@
+import SheshBeshGame
+import Testing
+
+@Suite("Match engine errors")
+struct MatchEngineErrorTests {
+    @Test("Opening roll rejects invalid dice values")
+    func openingRollRejectsInvalidDiceValues() {
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([0, 4]))
+        let state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+
+        expectMatchEngineError(.invalidDiceValue) {
+            _ = try engine.apply(action: .rollOpeningDice, to: state)
+        }
+    }
+
+    @Test("Rolling dice rejects invalid dice values")
+    func turnRollRejectsInvalidDiceValues() {
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([3, 7]))
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        expectMatchEngineError(.invalidDiceValue) {
+            _ = try engine.apply(action: .rollDice(.white), to: state)
+        }
+    }
+
+    @Test("Opening roll is rejected outside the opening phase")
+    func openingRollOutsideOpeningPhaseThrowsInvalidAction() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .rollOpeningDice, to: state)
+        }
+    }
+
+    @Test("Rolling is rejected for the wrong player")
+    func wrongPlayerRollThrowsInvalidAction() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .rollDice(.black), to: state)
+        }
+    }
+
+    @Test("Rolling is rejected during checker movement")
+    func rollDuringMovePhaseThrowsInvalidAction() throws {
+        let state = try makeMatch(board: .initial(), player: .white, dice: [4, 1])
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .rollDice(.white), to: state)
+        }
+    }
+
+    @Test("Moves are rejected outside checker movement")
+    func moveOutsideMovePhaseThrowsInvalidAction() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let move = Move(player: .white, source: .point(point(24)), destination: .point(point(21)), die: 3)
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .move(move), to: state)
+        }
+    }
+
+    @Test("Illegal moves report the rejected move")
+    func illegalMoveReportsRejectedMove() throws {
+        let state = try makeMatch(board: .initial(), player: .white, dice: [3, 1])
+        let move = Move(player: .white, source: .point(point(24)), destination: .point(point(20)), die: 4)
+
+        expectMatchEngineError(.illegalMove(move)) {
+            _ = try MatchEngine().apply(action: .move(move), to: state)
+        }
+    }
+
+    @Test("Opponent moves during a turn report the rejected move")
+    func opponentMoveReportsRejectedMove() throws {
+        let state = try makeMatch(board: .initial(), player: .white, dice: [3, 1])
+        let move = Move(player: .black, source: .point(point(1)), destination: .point(point(4)), die: 3)
+
+        expectMatchEngineError(.illegalMove(move)) {
+            _ = try MatchEngine().apply(action: .move(move), to: state)
+        }
+    }
+
+    @Test("Cube responses are rejected when no cube offer is pending")
+    func cubeResponsesWithoutOfferThrowInvalidAction() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .takeDouble(.black), to: state)
+        }
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .dropDouble(.black), to: state)
+        }
+    }
+
+    @Test("Cube responses are rejected for the offering player")
+    func cubeResponsesFromOffererThrowInvalidAction() throws {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let offered = try engine.apply(action: .offerDouble(.white), to: state)
+
+        expectInvalidMatchAction {
+            _ = try engine.apply(action: .takeDouble(.white), to: offered)
+        }
+        expectInvalidMatchAction {
+            _ = try engine.apply(action: .dropDouble(.white), to: offered)
+        }
+    }
+
+    @Test("Double offers are rejected when the player cannot offer")
+    func unavailableDoubleOfferThrowsInvalidAction() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingRoll(.white),
+                cube: CubeState(value: 2, owner: .black)
+            )
+        )
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .offerDouble(.white), to: state)
+        }
+    }
+
+    @Test("Resignation offers are rejected outside roll and move phases")
+    func resignationOfferOutsidePlayablePhaseThrowsInvalidAction() {
+        let state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .offerResignation(.white, .single), to: state)
+        }
+    }
+
+    @Test("Resignation responses are rejected when no resignation is pending")
+    func resignationResponsesWithoutOfferThrowInvalidAction() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .acceptResignation(.black), to: state)
+        }
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .rejectResignation(.black), to: state)
+        }
+    }
+
+    @Test("Resignation responses are rejected for the offering player")
+    func resignationResponsesFromOffererThrowInvalidAction() throws {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let offered = try engine.apply(action: .offerResignation(.white, .single), to: state)
+
+        expectInvalidMatchAction {
+            _ = try engine.apply(action: .acceptResignation(.white), to: offered)
+        }
+        expectInvalidMatchAction {
+            _ = try engine.apply(action: .rejectResignation(.white), to: offered)
+        }
+    }
+
+    @Test("Starting the next game is rejected before game over")
+    func startNextGameBeforeGameOverThrowsInvalidAction() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        expectInvalidMatchAction {
+            _ = try MatchEngine().apply(action: .startNextGame, to: state)
+        }
+    }
+
+    @Test("Actions after match completion throw matchAlreadyCompleted")
+    func actionsAfterMatchCompletionThrowMatchAlreadyCompleted() {
+        let state = MatchState(
+            config: .tournament(targetScore: 1),
+            score: MatchScore(white: 1, black: 0),
+            game: GameState(
+                board: .initial(),
+                phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 1))
+            ),
+            completion: MatchCompletion(winner: .white, finalScore: MatchScore(white: 1, black: 0))
+        )
+
+        expectMatchEngineError(.matchAlreadyCompleted) {
+            _ = try MatchEngine().apply(action: .rollOpeningDice, to: state)
+        }
+        expectMatchEngineError(.matchAlreadyCompleted) {
+            _ = try MatchEngine().apply(action: .startNextGame, to: state)
+        }
+    }
+}
+
+private func expectInvalidMatchAction(_ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected MatchEngineError.invalidAction")
+    } catch let error as MatchEngineError {
+        guard case .invalidAction(let message) = error else {
+            Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+            return
+        }
+        #expect(!message.isEmpty)
+    } catch {
+        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+    }
+}
+
+private func expectMatchEngineError(_ expected: MatchEngineError, _ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected \(expected)")
+    } catch let error as MatchEngineError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Expected \(expected), got \(error)")
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
@@ -3,6 +3,16 @@ import Testing
 
 @Suite("Match engine errors")
 struct MatchEngineErrorTests {
+    @Test("Dice roll initializer rejects invalid dice values")
+    func diceRollInitializerRejectsInvalidValues() {
+        expectMatchEngineError(.invalidDiceValue) {
+            _ = try DiceRoll(die1: 0, die2: 4)
+        }
+        expectMatchEngineError(.invalidDiceValue) {
+            _ = try DiceRoll(die1: 3, die2: 7)
+        }
+    }
+
     @Test("Opening roll rejects invalid dice values")
     func openingRollRejectsInvalidDiceValues() {
         let engine = MatchEngine(diceRoller: ScriptedDiceRoller([0, 4]))
@@ -33,7 +43,7 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rollOpeningDice, to: state)
         }
     }
@@ -45,7 +55,7 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rollDice(.black), to: state)
         }
     }
@@ -54,7 +64,7 @@ struct MatchEngineErrorTests {
     func rollDuringMovePhaseThrowsInvalidAction() throws {
         let state = try makeMatch(board: .initial(), player: .white, dice: [4, 1])
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rollDice(.white), to: state)
         }
     }
@@ -67,7 +77,7 @@ struct MatchEngineErrorTests {
         )
         let move = Move(player: .white, source: .point(point(24)), destination: .point(point(21)), die: 3)
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .move(move), to: state)
         }
     }
@@ -99,10 +109,10 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .takeDouble(.black), to: state)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .dropDouble(.black), to: state)
         }
     }
@@ -116,10 +126,10 @@ struct MatchEngineErrorTests {
         )
         let offered = try engine.apply(action: .offerDouble(.white), to: state)
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .takeDouble(.white), to: offered)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .dropDouble(.white), to: offered)
         }
     }
@@ -135,7 +145,7 @@ struct MatchEngineErrorTests {
             )
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .offerDouble(.white), to: state)
         }
     }
@@ -144,7 +154,7 @@ struct MatchEngineErrorTests {
     func resignationOfferOutsidePlayablePhaseThrowsInvalidAction() {
         let state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .offerResignation(.white, .single), to: state)
         }
     }
@@ -156,10 +166,10 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .acceptResignation(.black), to: state)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rejectResignation(.black), to: state)
         }
     }
@@ -173,10 +183,10 @@ struct MatchEngineErrorTests {
         )
         let offered = try engine.apply(action: .offerResignation(.white, .single), to: state)
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .acceptResignation(.white), to: offered)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .rejectResignation(.white), to: offered)
         }
     }
@@ -188,7 +198,7 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .startNextGame, to: state)
         }
     }
@@ -211,31 +221,5 @@ struct MatchEngineErrorTests {
         expectMatchEngineError(.matchAlreadyCompleted) {
             _ = try MatchEngine().apply(action: .startNextGame, to: state)
         }
-    }
-}
-
-private func expectInvalidMatchAction(_ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected MatchEngineError.invalidAction")
-    } catch let error as MatchEngineError {
-        guard case .invalidAction(let message) = error else {
-            Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
-            return
-        }
-        #expect(!message.isEmpty)
-    } catch {
-        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
-    }
-}
-
-private func expectMatchEngineError(_ expected: MatchEngineError, _ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected \(expected)")
-    } catch let error as MatchEngineError {
-        #expect(error == expected)
-    } catch {
-        Issue.record("Expected \(expected), got \(error)")
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
@@ -150,6 +150,15 @@ struct MatchEngineErrorTests {
         }
     }
 
+    @Test("Double offers are rejected during checker movement")
+    func doubleOfferDuringMovePhaseThrowsInvalidAction() throws {
+        let state = try makeMatch(board: .initial(), player: .white, dice: [4, 1])
+
+        expectInvalidAction {
+            _ = try MatchEngine().apply(action: .offerDouble(.white), to: state)
+        }
+    }
+
     @Test("Resignation offers are rejected outside roll and move phases")
     func resignationOfferOutsidePlayablePhaseThrowsInvalidAction() {
         let state = MatchEngine.newMatch(config: .tournament(targetScore: 5))

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -258,6 +258,46 @@ struct MatchEngineTests {
         #expect(result == GameResult(winner: .black, winKind: .gammon, cubeValue: 2))
     }
 
+    @Test("Scoring matrix matches win kind multipliers across cube values")
+    func scoringMatrixMatchesWinKindAndCubeValue() throws {
+        let cubeValues = [1, 2, 4, 8, 16, 32, 64]
+        let startingScore = MatchScore(white: 7, black: 13)
+
+        for winner in Player.allCases {
+            let loser = winner.opponent
+            for winKind in WinKind.allCases {
+                for cubeValue in cubeValues {
+                    let expectedPoints = cubeValue * winKind.multiplier
+                    let result = GameResult(winner: winner, winKind: winKind, cubeValue: cubeValue)
+                    #expect(result.points == expectedPoints)
+
+                    var state = MatchState(
+                        config: .tournament(targetScore: 500),
+                        score: startingScore,
+                        game: GameState(
+                            board: .initial(),
+                            phase: .awaitingRoll(loser),
+                            cube: CubeState(value: cubeValue, owner: winner)
+                        )
+                    )
+
+                    state = try MatchEngine().apply(action: .offerResignation(loser, winKind), to: state)
+                    state = try MatchEngine().apply(action: .acceptResignation(winner), to: state)
+
+                    #expect(state.score.score(for: winner) == startingScore.score(for: winner) + expectedPoints)
+                    #expect(state.score.score(for: loser) == startingScore.score(for: loser))
+                    #expect(state.completion == nil)
+
+                    guard case .gameOver(let scoredResult) = state.game.phase else {
+                        Issue.record("Expected game over after accepted resignation")
+                        continue
+                    }
+                    #expect(scoredResult == result)
+                }
+            }
+        }
+    }
+
     @Test("Rejected resignation resumes the previous phase")
     func rejectedResignationResumesPlay() throws {
         let engine = MatchEngine()

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -64,6 +64,7 @@ struct MatchEngineTests {
 
         #expect(state.game.board.point(point(1)) == PointState(owner: .white, count: 1))
         #expect(state.game.board.point(point(4)) == .empty)
+        #expect(state.game.board.barCount(for: .white) == 0)
         #expect(state.game.board.barCount(for: .black) == 1)
         #expect(state.game.phase == .awaitingRoll(.black))
     }
@@ -84,7 +85,60 @@ struct MatchEngineTests {
         )
         let next = try engine.apply(action: .rollDice(.white), to: state)
 
+        #expect(next.game.board == board)
         #expect(next.game.phase == .awaitingRoll(.black))
+    }
+
+    @Test("Legal actions at roll time are exactly roll, double, and resignations")
+    func legalActionsAtRollTimeArePinned() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        #expect(MatchEngine.legalActions(in: state) == [
+            .offerDouble(.white),
+            .rollDice(.white),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+    }
+
+    @Test("Legal actions at move time are exactly legal first moves and resignations")
+    func legalActionsAtMoveTimeArePinned() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(19), owner: .black, count: 15)
+
+        let state = try makeMatch(board: board, player: .white, dice: [1])
+        let checkerMove = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        #expect(MatchEngine.legalActions(in: state) == [
+            .move(checkerMove),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+    }
+
+    @Test("Disabling the doubling cube removes double offers")
+    func disablingDoublingCubeRemovesDoubleOffers() {
+        let state = MatchState(
+            config: MatchConfig(targetScore: 5, usesDoublingCube: false),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        #expect(MatchEngine.legalActions(in: state) == [
+            .rollDice(.white),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+        expectInvalidAction {
+            _ = try MatchEngine().apply(action: .offerDouble(.white), to: state)
+        }
     }
 
     @Test("Double take assigns cube ownership to the taker")
@@ -127,7 +181,7 @@ struct MatchEngineTests {
 
     @Test("Only the cube owner can redouble after a take")
     func onlyCubeOwnerCanRedouble() throws {
-        let engine = MatchEngine()
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1]))
         var state = MatchState(
             config: .tournament(targetScore: 5),
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
@@ -138,7 +192,10 @@ struct MatchEngineTests {
 
         #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
 
-        state.game.phase = .awaitingRoll(.black)
+        state = try engine.apply(action: .rollDice(.white), to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
+
+        #expect(state.game.phase == .awaitingRoll(.black))
         #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
@@ -181,11 +238,11 @@ struct MatchEngineTests {
 
     @Test("Crawford game disables the cube and is marked completed after the game")
     func crawfordGame() throws {
-        let engine = MatchEngine()
-        let previousResult = GameResult(winner: .white, winKind: .single, cubeValue: 1)
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 6, 1]))
+        let previousResult = GameResult(winner: .black, winKind: .single, cubeValue: 1)
         var state = MatchState(
             config: .tournament(targetScore: 3),
-            score: MatchScore(white: 2, black: 0),
+            score: MatchScore(white: 0, black: 2),
             game: GameState(board: .initial(), phase: .gameOver(previousResult)),
             crawfordState: .availableNextGame
         )
@@ -193,27 +250,29 @@ struct MatchEngineTests {
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.game.isCrawford)
 
-        state.game.phase = .awaitingRoll(.white)
-        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
 
-        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
-        state = try engine.apply(action: .acceptResignation(.black), to: state)
+        state = try engine.apply(action: .offerResignation(.black, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.white), to: state)
 
         #expect(state.crawfordState == .completed)
 
         state = try engine.apply(action: .startNextGame, to: state)
-        state.game.phase = .awaitingRoll(.white)
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
         #expect(!state.game.isCrawford)
-        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
     @Test("The doubling cube is available again after the Crawford game")
     func cubeAvailableAfterCrawfordGameCompletes() throws {
-        let engine = MatchEngine()
-        let previousResult = GameResult(winner: .white, winKind: .single, cubeValue: 1)
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 6, 1]))
+        let previousResult = GameResult(winner: .black, winKind: .single, cubeValue: 1)
         var state = MatchState(
             config: .tournament(targetScore: 4),
-            score: MatchScore(white: 3, black: 0),
+            score: MatchScore(white: 0, black: 3),
             game: GameState(board: .initial(), phase: .gameOver(previousResult)),
             crawfordState: .availableNextGame
         )
@@ -221,18 +280,20 @@ struct MatchEngineTests {
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.game.isCrawford)
 
-        state.game.phase = .awaitingRoll(.white)
-        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
 
-        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
-        state = try engine.apply(action: .acceptResignation(.black), to: state)
+        state = try engine.apply(action: .offerResignation(.black, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.white), to: state)
         #expect(state.crawfordState == .completed)
 
         state = try engine.apply(action: .startNextGame, to: state)
-        state.game.phase = .awaitingRoll(.white)
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
 
         #expect(!state.game.isCrawford)
-        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
     @Test("Accepted resignation scores the offered result")
@@ -347,6 +408,7 @@ struct MatchEngineTests {
         let next = try MatchEngine().apply(action: .move(move), to: state)
 
         #expect(next.score.score(for: .white) == 3)
+        #expect(next.game.board.borneOffCount(for: .white) == 15)
         guard case .gameOver(let result) = next.game.phase else {
             Issue.record("Expected game over after final checker bears off")
             return
@@ -487,18 +549,100 @@ struct MatchEngineTests {
         #expect(state.score.score(for: .black) == 1)
         #expect(state.crawfordState == .availableNextGame)
     }
-}
 
-private func expectInvalidAction(_ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected invalid action")
-    } catch let error as MatchEngineError {
-        guard case .invalidAction = error else {
-            Issue.record("Expected invalid action, got \(error)")
-            return
-        }
-    } catch {
-        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+    @Test("Crawford stays unavailable when the rule is disabled")
+    func crawfordRuleDisabledKeepsStateNotReached() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: MatchConfig(targetScore: 3, usesCrawfordRule: false),
+            score: MatchScore(white: 0, black: 1),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 2)
+        #expect(state.crawfordState == .notReached)
+        #expect(state.completion == nil)
+    }
+
+    @Test("Crawford is queued when either player reaches one away")
+    func crawfordIsQueuedWhenEitherPlayerReachesOneAway() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 3),
+            score: MatchScore(white: 2, black: 1),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .white) == 2)
+        #expect(state.score.score(for: .black) == 2)
+        #expect(state.crawfordState == .availableNextGame)
+    }
+
+    @Test("Starting the next game increments gameNumber")
+    func startNextGameIncrementsGameNumber() throws {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 1))
+            ),
+            gameNumber: 3
+        )
+
+        let next = try engine.apply(action: .startNextGame, to: state)
+
+        #expect(next.gameNumber == 4)
+        #expect(next.game.phase == .awaitingOpeningRoll)
+    }
+
+    @Test("Bear-off can queue Crawford and continue to the post-Crawford game")
+    func bearOffQueuesCrawfordThenMatchContinuesAfterCrawford() throws {
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 6, 1]))
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(7), owner: .black, count: 14)
+        try board.setBorneOff(for: .black, count: 1)
+
+        var state = try makeMatch(
+            board: board,
+            player: .white,
+            dice: [1],
+            config: .tournament(targetScore: 4),
+            score: MatchScore(white: 2, black: 0)
+        )
+
+        state = try engine.apply(
+            action: .move(Move(player: .white, source: .point(point(1)), destination: .off, die: 1)),
+            to: state
+        )
+
+        #expect(state.score.score(for: .white) == 3)
+        #expect(state.crawfordState == .availableNextGame)
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        #expect(state.gameNumber == 2)
+        #expect(state.game.phase == .awaitingOpeningRoll)
+        #expect(state.game.isCrawford)
+
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 1)
+        #expect(state.crawfordState == .completed)
+        #expect(state.completion == nil)
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        #expect(state.gameNumber == 3)
+        #expect(!state.game.isCrawford)
+        #expect(state.game.phase == .awaitingOpeningRoll)
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -72,8 +72,8 @@ struct MatchEngineTests {
         #expect(state.game.phase == .awaitingRoll(.black))
     }
 
-    @Test("A roll with no legal moves automatically passes the turn")
-    func automaticPass() throws {
+    @Test("A roll with no legal moves preserves the turn until passed")
+    func blockedRollPreservesDiceUntilPassed() throws {
         var board = Board.empty()
         try board.setBar(for: .white, count: 1)
         try board.setBorneOff(for: .white, count: 14)
@@ -89,7 +89,65 @@ struct MatchEngineTests {
         let next = try engine.apply(action: .rollDice(.white), to: state)
 
         #expect(next.game.board == board)
-        #expect(next.game.phase == .awaitingRoll(.black))
+        guard case .awaitingMove(let turn) = next.game.phase else {
+            Issue.record("Expected blocked roll to remain awaitingMove")
+            return
+        }
+        #expect(turn.player == .white)
+        #expect(turn.roll == (try DiceRoll(die1: 1, die2: 2)))
+        #expect(turn.remainingDice == [1, 2])
+        #expect(MatchEngine.legalActions(in: next) == [
+            .passTurn(.white),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+
+        let passed = try engine.apply(action: .passTurn(.white), to: next)
+        #expect(passed.game.board == board)
+        #expect(passed.game.phase == .awaitingRoll(.black))
+    }
+
+    @Test("Blocked remaining dice preserve the turn until passed")
+    func blockedRemainingDicePreserveTurnUntilPassed() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(4), owner: .black, count: 2)
+        try board.setBorneOff(for: .black, count: 13)
+
+        let engine = MatchEngine()
+        var state = try makeMatch(board: board, player: .white, dice: [1, 1, 1, 1])
+        let move = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        state = try engine.apply(action: .move(move), to: state)
+
+        guard case .awaitingMove(let turn) = state.game.phase else {
+            Issue.record("Expected blocked remaining dice to remain awaitingMove")
+            return
+        }
+        #expect(turn.player == .white)
+        #expect(turn.roll == (try DiceRoll(die1: 1, die2: 1)))
+        #expect(turn.remainingDice == [1, 1, 1])
+        #expect(MatchEngine.legalActions(in: state).contains(.passTurn(.white)))
+
+        state = try engine.apply(action: .passTurn(.white), to: state)
+        #expect(state.game.phase == .awaitingRoll(.black))
+    }
+
+    @Test("A turn with legal moves cannot be passed")
+    func legalMoveTurnCannotBePassed() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(19), owner: .black, count: 15)
+
+        let state = try makeMatch(board: board, player: .white, dice: [1])
+
+        #expect(!MatchEngine.legalActions(in: state).contains(.passTurn(.white)))
+        expectInvalidAction {
+            _ = try MatchEngine().apply(action: .passTurn(.white), to: state)
+        }
     }
 
     @Test("Legal actions at roll time are exactly roll, double, and resignations")

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -1,0 +1,279 @@
+import SheshBeshGame
+import Testing
+
+@Suite("Match engine")
+struct MatchEngineTests {
+    @Test("Opening roll rerolls ties and starts the higher die")
+    func openingRoll() throws {
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([3, 3, 6, 2]))
+        var state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        #expect(state.game.phase == .awaitingOpeningRoll)
+
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        guard case .awaitingMove(let turn) = state.game.phase else {
+            Issue.record("Expected white to be awaiting checker movement")
+            return
+        }
+
+        #expect(turn.player == .white)
+        #expect(turn.roll.die1 == 6)
+        #expect(turn.roll.die2 == 2)
+        #expect(turn.remainingDice == [6, 2])
+    }
+
+    @Test("Applying a hit moves the blot to the bar")
+    func hitMovesBlotToBar() throws {
+        var board = Board.empty()
+        try board.setPoint(point(8), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(5), owner: .black, count: 1)
+        try board.setBorneOff(for: .black, count: 14)
+
+        let state = try makeMatch(board: board, player: .white, dice: [3])
+        let move = Move(player: .white, source: .point(point(8)), destination: .point(point(5)), die: 3)
+        let next = try MatchEngine().apply(action: .move(move), to: state)
+
+        #expect(next.game.board.point(point(5)) == PointState(owner: .white, count: 1))
+        #expect(next.game.board.barCount(for: .black) == 1)
+        #expect(next.game.board.totalCheckers(for: .white) == 15)
+        #expect(next.game.board.totalCheckers(for: .black) == 15)
+    }
+
+    @Test("A roll with no legal moves automatically passes the turn")
+    func automaticPass() throws {
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(24), owner: .black, count: 2)
+        try board.setPoint(point(23), owner: .black, count: 2)
+        try board.setBorneOff(for: .black, count: 11)
+
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([1, 2]))
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: board, phase: .awaitingRoll(.white))
+        )
+        let next = try engine.apply(action: .rollDice(.white), to: state)
+
+        #expect(next.game.phase == .awaitingRoll(.black))
+    }
+
+    @Test("Double take assigns cube ownership to the taker")
+    func doubleTake() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerDouble(.white), to: state)
+        state = try engine.apply(action: .takeDouble(.black), to: state)
+
+        #expect(state.game.cube == CubeState(value: 2, owner: .black))
+        #expect(state.game.phase == .awaitingRoll(.white))
+    }
+
+    @Test("Dropping a double awards the previous cube value")
+    func dropDoubleAwardsPreviousCubeValue() throws {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingRoll(.white),
+                cube: CubeState(value: 2, owner: .white)
+            )
+        )
+
+        let offered = try engine.apply(action: .offerDouble(.white), to: state)
+        let dropped = try engine.apply(action: .dropDouble(.black), to: offered)
+
+        #expect(dropped.score.score(for: .white) == 2)
+        guard case .gameOver(let result) = dropped.game.phase else {
+            Issue.record("Expected game over after dropped double")
+            return
+        }
+        #expect(result == GameResult(winner: .white, winKind: .single, cubeValue: 2))
+    }
+
+    @Test("Only the cube owner can redouble after a take")
+    func onlyCubeOwnerCanRedouble() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerDouble(.white), to: state)
+        state = try engine.apply(action: .takeDouble(.black), to: state)
+
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+
+        state.game.phase = .awaitingRoll(.black)
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
+    }
+
+    @Test("Crawford game disables the cube and is marked completed after the game")
+    func crawfordGame() throws {
+        let engine = MatchEngine()
+        let previousResult = GameResult(winner: .white, winKind: .single, cubeValue: 1)
+        var state = MatchState(
+            config: .tournament(targetScore: 3),
+            score: MatchScore(white: 2, black: 0),
+            game: GameState(board: .initial(), phase: .gameOver(previousResult)),
+            crawfordState: .availableNextGame
+        )
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        #expect(state.game.isCrawford)
+
+        state.game.phase = .awaitingRoll(.white)
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.crawfordState == .completed)
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        state.game.phase = .awaitingRoll(.white)
+        #expect(!state.game.isCrawford)
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+    }
+
+    @Test("Accepted resignation scores the offered result")
+    func resignationScoring() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 7),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingRoll(.white),
+                cube: CubeState(value: 2, owner: .black)
+            )
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .gammon), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 4)
+        guard case .gameOver(let result) = state.game.phase else {
+            Issue.record("Expected game over after accepted resignation")
+            return
+        }
+        #expect(result == GameResult(winner: .black, winKind: .gammon, cubeValue: 2))
+    }
+
+    @Test("Rejected resignation resumes the previous phase")
+    func rejectedResignationResumesPlay() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .rejectResignation(.black), to: state)
+
+        #expect(state.game.phase == .awaitingRoll(.white))
+    }
+
+    @Test("Bearing off the last checker classifies backgammon")
+    func bearingOffLastCheckerEndsGame() throws {
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(2), owner: .black, count: 1)
+        try board.setPoint(point(19), owner: .black, count: 14)
+
+        let state = try makeMatch(
+            board: board,
+            player: .white,
+            dice: [1],
+            config: .tournament(targetScore: 7)
+        )
+        let move = Move(player: .white, source: .point(point(1)), destination: .off, die: 1)
+        let next = try MatchEngine().apply(action: .move(move), to: state)
+
+        #expect(next.score.score(for: .white) == 3)
+        guard case .gameOver(let result) = next.game.phase else {
+            Issue.record("Expected game over after final checker bears off")
+            return
+        }
+        #expect(result == GameResult(winner: .white, winKind: .backgammon, cubeValue: 1))
+    }
+
+    @Test("Bearing off the last checker classifies single and gammon wins")
+    func finalCheckerClassifiesSingleAndGammon() throws {
+        var singleBoard = Board.empty()
+        try singleBoard.setPoint(point(1), owner: .white, count: 1)
+        try singleBoard.setBorneOff(for: .white, count: 14)
+        try singleBoard.setPoint(point(7), owner: .black, count: 14)
+        try singleBoard.setBorneOff(for: .black, count: 1)
+
+        var state = try makeMatch(board: singleBoard, player: .white, dice: [1])
+        var next = try MatchEngine().apply(
+            action: .move(Move(player: .white, source: .point(point(1)), destination: .off, die: 1)),
+            to: state
+        )
+
+        guard case .gameOver(let singleResult) = next.game.phase else {
+            Issue.record("Expected game over for single win")
+            return
+        }
+        #expect(singleResult.winKind == .single)
+
+        var gammonBoard = Board.empty()
+        try gammonBoard.setPoint(point(1), owner: .white, count: 1)
+        try gammonBoard.setBorneOff(for: .white, count: 14)
+        try gammonBoard.setPoint(point(7), owner: .black, count: 15)
+
+        state = try makeMatch(board: gammonBoard, player: .white, dice: [1])
+        next = try MatchEngine().apply(
+            action: .move(Move(player: .white, source: .point(point(1)), destination: .off, die: 1)),
+            to: state
+        )
+
+        guard case .gameOver(let gammonResult) = next.game.phase else {
+            Issue.record("Expected game over for gammon win")
+            return
+        }
+        #expect(gammonResult.winKind == .gammon)
+    }
+
+    @Test("Match completion is recorded when the target score is reached")
+    func matchCompletion() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 3),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingRoll(.white),
+                cube: CubeState(value: 2, owner: .black)
+            )
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .gammon), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.completion == MatchCompletion(winner: .black, finalScore: state.score))
+        #expect(MatchEngine.legalActions(in: state).isEmpty)
+    }
+
+    @Test("A player who is one point away triggers Crawford for the next game")
+    func crawfordIsQueuedAtOneAway() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 2),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 1)
+        #expect(state.crawfordState == .availableNextGame)
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -8,8 +8,11 @@ struct MatchEngineTests {
         let engine = MatchEngine(diceRoller: ScriptedDiceRoller([3, 3, 6, 2]))
         var state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
 
+        let initialState = state
         state = try engine.apply(action: .rollOpeningDice, to: state)
-        #expect(state.game.phase == .awaitingOpeningRoll)
+        let tiedRoll = try DiceRoll(die1: 3, die2: 3)
+        #expect(state != initialState)
+        #expect(state.game.phase == .awaitingOpeningRoll(tiedRoll: tiedRoll))
 
         state = try engine.apply(action: .rollOpeningDice, to: state)
         guard case .awaitingMove(let turn) = state.game.phase else {
@@ -599,7 +602,7 @@ struct MatchEngineTests {
         let next = try engine.apply(action: .startNextGame, to: state)
 
         #expect(next.gameNumber == 4)
-        #expect(next.game.phase == .awaitingOpeningRoll)
+        #expect(next.game.phase == .awaitingOpeningRoll())
     }
 
     @Test("Bear-off can queue Crawford and continue to the post-Crawford game")
@@ -629,7 +632,7 @@ struct MatchEngineTests {
 
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.gameNumber == 2)
-        #expect(state.game.phase == .awaitingOpeningRoll)
+        #expect(state.game.phase == .awaitingOpeningRoll())
         #expect(state.game.isCrawford)
 
         state = try engine.apply(action: .rollOpeningDice, to: state)
@@ -643,6 +646,6 @@ struct MatchEngineTests {
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.gameNumber == 3)
         #expect(!state.game.isCrawford)
-        #expect(state.game.phase == .awaitingOpeningRoll)
+        #expect(state.game.phase == .awaitingOpeningRoll())
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -26,8 +26,8 @@ struct MatchEngineTests {
     @Test("Applying a hit moves the blot to the bar")
     func hitMovesBlotToBar() throws {
         var board = Board.empty()
-        try board.setPoint(point(8), owner: .white, count: 1)
-        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(8), owner: .white, count: 2)
+        try board.setBorneOff(for: .white, count: 13)
         try board.setPoint(point(5), owner: .black, count: 1)
         try board.setBorneOff(for: .black, count: 14)
 
@@ -35,10 +35,37 @@ struct MatchEngineTests {
         let move = Move(player: .white, source: .point(point(8)), destination: .point(point(5)), die: 3)
         let next = try MatchEngine().apply(action: .move(move), to: state)
 
+        #expect(next.game.board.point(point(8)) == PointState(owner: .white, count: 1))
         #expect(next.game.board.point(point(5)) == PointState(owner: .white, count: 1))
         #expect(next.game.board.barCount(for: .black) == 1)
         #expect(next.game.board.totalCheckers(for: .white) == 15)
         #expect(next.game.board.totalCheckers(for: .black) == 15)
+    }
+
+    @Test("A checker can hit in the home board and continue with the second die")
+    func hitAndRunInHomeBoard() throws {
+        let engine = MatchEngine()
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(4), owner: .black, count: 1)
+        try board.setBorneOff(for: .black, count: 14)
+
+        var state = try makeMatch(board: board, player: .white, dice: [2, 3])
+        let hit = Move(player: .white, source: .point(point(6)), destination: .point(point(4)), die: 2)
+        let run = Move(player: .white, source: .point(point(4)), destination: .point(point(1)), die: 3)
+
+        #expect(MatchEngine.legalActions(in: state).contains(.move(hit)))
+        state = try engine.apply(action: .move(hit), to: state)
+
+        #expect(state.game.board.barCount(for: .black) == 1)
+        #expect(MatchEngine.legalActions(in: state).contains(.move(run)))
+        state = try engine.apply(action: .move(run), to: state)
+
+        #expect(state.game.board.point(point(1)) == PointState(owner: .white, count: 1))
+        #expect(state.game.board.point(point(4)) == .empty)
+        #expect(state.game.board.barCount(for: .black) == 1)
+        #expect(state.game.phase == .awaitingRoll(.black))
     }
 
     @Test("A roll with no legal moves automatically passes the turn")
@@ -115,6 +142,43 @@ struct MatchEngineTests {
         #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
+    @Test("Doubling is unavailable once the cube reaches the configured maximum")
+    func maximumCubeValueStopsFurtherDoubles() throws {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: MatchConfig(targetScore: 7, maximumCubeValue: 4),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingRoll(.white),
+                cube: CubeState(value: 4, owner: .white)
+            )
+        )
+
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerDouble(.white), to: state)
+        }
+    }
+
+    @Test("The taker cannot immediately redouble before their turn")
+    func takerCannotImmediatelyRedouble() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerDouble(.white), to: state)
+        state = try engine.apply(action: .takeDouble(.black), to: state)
+
+        #expect(state.game.phase == .awaitingRoll(.white))
+        #expect(state.game.cube == CubeState(value: 2, owner: .black))
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerDouble(.black), to: state)
+        }
+    }
+
     @Test("Crawford game disables the cube and is marked completed after the game")
     func crawfordGame() throws {
         let engine = MatchEngine()
@@ -139,6 +203,34 @@ struct MatchEngineTests {
 
         state = try engine.apply(action: .startNextGame, to: state)
         state.game.phase = .awaitingRoll(.white)
+        #expect(!state.game.isCrawford)
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+    }
+
+    @Test("The doubling cube is available again after the Crawford game")
+    func cubeAvailableAfterCrawfordGameCompletes() throws {
+        let engine = MatchEngine()
+        let previousResult = GameResult(winner: .white, winKind: .single, cubeValue: 1)
+        var state = MatchState(
+            config: .tournament(targetScore: 4),
+            score: MatchScore(white: 3, black: 0),
+            game: GameState(board: .initial(), phase: .gameOver(previousResult)),
+            crawfordState: .availableNextGame
+        )
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        #expect(state.game.isCrawford)
+
+        state.game.phase = .awaitingRoll(.white)
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+        #expect(state.crawfordState == .completed)
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        state.game.phase = .awaitingRoll(.white)
+
         #expect(!state.game.isCrawford)
         #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
     }
@@ -222,6 +314,25 @@ struct MatchEngineTests {
         #expect(result == GameResult(winner: .white, winKind: .backgammon, cubeValue: 1))
     }
 
+    @Test("Bearing off the last checker classifies backgammon when the loser is on the bar")
+    func finalCheckerClassifiesBackgammonFromBar() throws {
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setBar(for: .black, count: 1)
+        try board.setPoint(point(19), owner: .black, count: 14)
+
+        let state = try makeMatch(board: board, player: .white, dice: [1])
+        let move = Move(player: .white, source: .point(point(1)), destination: .off, die: 1)
+        let next = try MatchEngine().apply(action: .move(move), to: state)
+
+        guard case .gameOver(let result) = next.game.phase else {
+            Issue.record("Expected game over after final checker bears off")
+            return
+        }
+        #expect(result == GameResult(winner: .white, winKind: .backgammon, cubeValue: 1))
+    }
+
     @Test("Bearing off the last checker classifies single and gammon wins")
     func finalCheckerClassifiesSingleAndGammon() throws {
         var singleBoard = Board.empty()
@@ -295,6 +406,33 @@ struct MatchEngineTests {
         #expect(state.completion == MatchCompletion(winner: .black, finalScore: state.score))
     }
 
+    @Test("A high cube backgammon completes the match when it overshoots the target")
+    func highCubeBackgammonCanCompleteMatchBeyondTarget() throws {
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setBar(for: .black, count: 1)
+        try board.setPoint(point(19), owner: .black, count: 14)
+
+        let state = try makeMatch(
+            board: board,
+            player: .white,
+            dice: [1],
+            config: .tournament(targetScore: 5),
+            cube: CubeState(value: 4, owner: .black)
+        )
+        let move = Move(player: .white, source: .point(point(1)), destination: .off, die: 1)
+        let next = try MatchEngine().apply(action: .move(move), to: state)
+
+        #expect(next.score.score(for: .white) == 12)
+        #expect(next.completion == MatchCompletion(winner: .white, finalScore: next.score))
+        guard case .gameOver(let result) = next.game.phase else {
+            Issue.record("Expected game over after final checker bears off")
+            return
+        }
+        #expect(result == GameResult(winner: .white, winKind: .backgammon, cubeValue: 4))
+    }
+
     @Test("A player who is one point away triggers Crawford for the next game")
     func crawfordIsQueuedAtOneAway() throws {
         let engine = MatchEngine()
@@ -308,5 +446,19 @@ struct MatchEngineTests {
 
         #expect(state.score.score(for: .black) == 1)
         #expect(state.crawfordState == .availableNextGame)
+    }
+}
+
+private func expectInvalidAction(_ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected invalid action")
+    } catch let error as MatchEngineError {
+        guard case .invalidAction = error else {
+            Issue.record("Expected invalid action, got \(error)")
+            return
+        }
+    } catch {
+        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -180,6 +180,23 @@ struct MatchEngineTests {
         #expect(state.game.phase == .awaitingRoll(.white))
     }
 
+    @Test("Rejected resignation restores awaitingMove turns")
+    func rejectedResignationResumesAwaitingMove() throws {
+        let engine = MatchEngine()
+        let board = Board.initial()
+        var state = try makeMatch(board: board, player: .white, dice: [4, 1])
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .rejectResignation(.black), to: state)
+
+        guard case .awaitingMove(let turn) = state.game.phase else {
+            Issue.record("Expected awaitingMove after resignation rejection")
+            return
+        }
+        #expect(turn.player == .white)
+        #expect(turn.remainingDice == [4, 1])
+    }
+
     @Test("Bearing off the last checker classifies backgammon")
     func bearingOffLastCheckerEndsGame() throws {
         var board = Board.empty()
@@ -260,6 +277,22 @@ struct MatchEngineTests {
 
         #expect(state.completion == MatchCompletion(winner: .black, finalScore: state.score))
         #expect(MatchEngine.legalActions(in: state).isEmpty)
+    }
+
+    @Test("Match completion is recorded when points exceed targetScore")
+    func matchCompletionWhenScoreExceedsTarget() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 3),
+            score: MatchScore(white: 0, black: 2),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .gammon), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 4)
+        #expect(state.completion == MatchCompletion(winner: .black, finalScore: state.score))
     }
 
     @Test("A player who is one point away triggers Crawford for the next game")

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
@@ -62,6 +62,19 @@ struct MoveValidatorTests {
         ])
     }
 
+    @Test("Higher die remains forced when only one checker can enter from a stacked bar")
+    func higherDieRuleWithMultipleBarCheckers() throws {
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 2)
+        try board.setPoint(point(24), owner: .black, count: 2)
+
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [1, 2])
+
+        #expect(firstMoves == [
+            Move(player: .white, source: .bar, destination: .point(point(23)), die: 2),
+        ])
+    }
+
     @Test("Oversize bear-off requires no checker farther from home")
     func oversizeBearOff() throws {
         var blocked = Board.empty()
@@ -105,6 +118,17 @@ struct MoveValidatorTests {
         #expect(sequences.allSatisfy { $0.moves.count == 4 })
     }
 
+    @Test("Doubles force the maximum available count even when fewer than four can be played")
+    func doublesUseMaximumAvailableCountWhenPartial() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 2)
+
+        let sequences = MoveValidator.legalMoves(for: .white, board: board, dice: [6, 6, 6, 6])
+
+        #expect(!sequences.isEmpty)
+        #expect(sequences.allSatisfy { $0.moves.count == 2 })
+    }
+
     @Test("Black moves upward and bears off from the high board")
     func blackMovementAndBearOff() throws {
         var board = Board.empty()
@@ -132,6 +156,24 @@ struct MoveValidatorTests {
 
         #expect(firstMoves == [
             Move(player: .black, source: .bar, destination: .point(point(4)), die: 4),
+        ])
+    }
+
+    @Test("Black oversize bear-off uses point 19 before point 20")
+    func blackOversizeBearOffPrefersFartherChecker() throws {
+        var board = Board.empty()
+        try board.setPoint(point(20), owner: .black, count: 1)
+        try board.setPoint(point(19), owner: .black, count: 1)
+
+        let blockedOversize = MoveValidator.legalFirstMoves(for: .black, board: board, dice: [6])
+        #expect(blockedOversize == [
+            Move(player: .black, source: .point(point(19)), destination: .off, die: 6),
+        ])
+
+        try board.setPoint(point(19), owner: nil, count: 0)
+        let allowedOversize = MoveValidator.legalFirstMoves(for: .black, board: board, dice: [6])
+        #expect(allowedOversize == [
+            Move(player: .black, source: .point(point(20)), destination: .off, die: 6),
         ])
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
@@ -36,13 +36,32 @@ struct MoveValidatorTests {
         ])
     }
 
+    @Test("Blocked bar entries still force entering as many checkers as possible")
+    func blockedBarEntriesUseMaximumBarMoves() throws {
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 2)
+        try board.setPoint(point(8), owner: .white, count: 1)
+        try board.setPoint(point(24), owner: .black, count: 2)
+
+        let forcedEntry = Move(player: .white, source: .bar, destination: .point(point(23)), die: 2)
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [1, 2])
+        let sequences = MoveValidator.legalMoves(for: .white, board: board, dice: [1, 2])
+
+        #expect(firstMoves == [forcedEntry])
+        #expect(sequences == [MoveSequence(moves: [forcedEntry])])
+    }
+
     @Test("Move generation prefers using more dice over a larger immediate die")
     func maximumDiceUseBeatsImmediateHighDie() throws {
         var board = Board.empty()
         try board.setPoint(point(6), owner: .white, count: 1)
 
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [1, 6])
         let sequences = MoveValidator.legalMoves(for: .white, board: board, dice: [1, 6])
 
+        #expect(firstMoves == [
+            Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1),
+        ])
         #expect(sequences.contains(MoveSequence(moves: [
             Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1),
             Move(player: .white, source: .point(point(5)), destination: .off, die: 6),

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
@@ -66,7 +66,12 @@ struct MoveValidatorTests {
             Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1),
             Move(player: .white, source: .point(point(5)), destination: .off, die: 6),
         ])))
-        #expect(sequences.allSatisfy { $0.moves.count == 2 })
+        #expect(sequences == [
+            MoveSequence(moves: [
+                Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1),
+                Move(player: .white, source: .point(point(5)), destination: .off, die: 6),
+            ]),
+        ])
     }
 
     @Test("When only one die can be played, the higher die is forced")
@@ -104,6 +109,7 @@ struct MoveValidatorTests {
         #expect(blockedMoves == [
             Move(player: .white, source: .point(point(6)), destination: .off, die: 6),
         ])
+        #expect(!blockedMoves.contains(Move(player: .white, source: .point(point(5)), destination: .off, die: 6)))
 
         var allowed = Board.empty()
         try allowed.setPoint(point(5), owner: .white, count: 1)
@@ -194,5 +200,16 @@ struct MoveValidatorTests {
         #expect(allowedOversize == [
             Move(player: .black, source: .point(point(20)), destination: .off, die: 6),
         ])
+    }
+
+    @Test("Game phase helpers return no moves outside the matching turn")
+    func gamePhaseHelpersRequireAwaitingMoveForPlayer() throws {
+        let awaitingRoll = GameState(board: .initial(), phase: .awaitingRoll(.white))
+        #expect(MoveValidator.legalMoves(for: .white, in: awaitingRoll).isEmpty)
+        #expect(MoveValidator.legalFirstMoves(for: .white, in: awaitingRoll).isEmpty)
+
+        let awaitingWhiteMove = try makeGame(board: .initial(), player: .white, dice: [3, 1])
+        #expect(MoveValidator.legalMoves(for: .black, in: awaitingWhiteMove).isEmpty)
+        #expect(MoveValidator.legalFirstMoves(for: .black, in: awaitingWhiteMove).isEmpty)
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
@@ -1,0 +1,137 @@
+import SheshBeshGame
+import Testing
+
+@Suite("Move validation")
+struct MoveValidatorTests {
+    @Test("Initial board exposes normal checker moves")
+    func initialBoardNormalMoves() {
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: .initial(), dice: [3, 1])
+
+        #expect(firstMoves.contains(Move(player: .white, source: .point(point(24)), destination: .point(point(21)), die: 3)))
+        #expect(firstMoves.contains(Move(player: .white, source: .point(point(24)), destination: .point(point(23)), die: 1)))
+    }
+
+    @Test("Blocked points cannot be used as destinations")
+    func blockedDestination() throws {
+        var board = Board.empty()
+        try board.setPoint(point(8), owner: .white, count: 1)
+        try board.setPoint(point(5), owner: .black, count: 2)
+
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [3])
+
+        #expect(!firstMoves.contains(Move(player: .white, source: .point(point(8)), destination: .point(point(5)), die: 3)))
+        #expect(firstMoves.isEmpty)
+    }
+
+    @Test("Bar checkers must enter before other checkers move")
+    func barPriority() throws {
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 1)
+        try board.setPoint(point(8), owner: .white, count: 1)
+
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [3])
+
+        #expect(firstMoves == [
+            Move(player: .white, source: .bar, destination: .point(point(22)), die: 3),
+        ])
+    }
+
+    @Test("Move generation prefers using more dice over a larger immediate die")
+    func maximumDiceUseBeatsImmediateHighDie() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+
+        let sequences = MoveValidator.legalMoves(for: .white, board: board, dice: [1, 6])
+
+        #expect(sequences.contains(MoveSequence(moves: [
+            Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1),
+            Move(player: .white, source: .point(point(5)), destination: .off, die: 6),
+        ])))
+        #expect(sequences.allSatisfy { $0.moves.count == 2 })
+    }
+
+    @Test("When only one die can be played, the higher die is forced")
+    func higherDieRule() throws {
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 1)
+
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [1, 2])
+
+        #expect(firstMoves == [
+            Move(player: .white, source: .point(point(1)), destination: .off, die: 2),
+        ])
+    }
+
+    @Test("Oversize bear-off requires no checker farther from home")
+    func oversizeBearOff() throws {
+        var blocked = Board.empty()
+        try blocked.setPoint(point(6), owner: .white, count: 1)
+        try blocked.setPoint(point(5), owner: .white, count: 1)
+
+        let blockedMoves = MoveValidator.legalFirstMoves(for: .white, board: blocked, dice: [6])
+        #expect(blockedMoves == [
+            Move(player: .white, source: .point(point(6)), destination: .off, die: 6),
+        ])
+
+        var allowed = Board.empty()
+        try allowed.setPoint(point(5), owner: .white, count: 1)
+
+        let allowedMoves = MoveValidator.legalFirstMoves(for: .white, board: allowed, dice: [6])
+        #expect(allowedMoves == [
+            Move(player: .white, source: .point(point(5)), destination: .off, die: 6),
+        ])
+    }
+
+    @Test("Bearing off is illegal while a checker remains outside the home board")
+    func cannotBearOffWithCheckerOutsideHome() throws {
+        var board = Board.empty()
+        try board.setPoint(point(7), owner: .white, count: 1)
+        try board.setPoint(point(5), owner: .white, count: 1)
+
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [5])
+
+        #expect(!firstMoves.contains(Move(player: .white, source: .point(point(5)), destination: .off, die: 5)))
+        #expect(firstMoves.contains(Move(player: .white, source: .point(point(7)), destination: .point(point(2)), die: 5)))
+    }
+
+    @Test("Doubles can be played up to four times")
+    func doublesUseFourMoves() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 4)
+
+        let sequences = MoveValidator.legalMoves(for: .white, board: board, dice: [1, 1, 1, 1])
+
+        #expect(!sequences.isEmpty)
+        #expect(sequences.allSatisfy { $0.moves.count == 4 })
+    }
+
+    @Test("Black moves upward and bears off from the high board")
+    func blackMovementAndBearOff() throws {
+        var board = Board.empty()
+        try board.setPoint(point(19), owner: .black, count: 1)
+        try board.setPoint(point(20), owner: .black, count: 1)
+
+        let blockedOversize = MoveValidator.legalFirstMoves(for: .black, board: board, dice: [6])
+        #expect(blockedOversize == [
+            Move(player: .black, source: .point(point(19)), destination: .off, die: 6),
+        ])
+
+        try board.setPoint(point(19), owner: nil, count: 0)
+        let allowedOversize = MoveValidator.legalFirstMoves(for: .black, board: board, dice: [6])
+        #expect(allowedOversize == [
+            Move(player: .black, source: .point(point(20)), destination: .off, die: 6),
+        ])
+    }
+
+    @Test("Black enters from the bar using the rolled die")
+    func blackBarEntry() throws {
+        var board = Board.empty()
+        try board.setBar(for: .black, count: 1)
+
+        let firstMoves = MoveValidator.legalFirstMoves(for: .black, board: board, dice: [4])
+
+        #expect(firstMoves == [
+            Move(player: .black, source: .bar, destination: .point(point(4)), die: 4),
+        ])
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
@@ -56,6 +56,13 @@ struct SerializationTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
         let openingState = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+        let tiedOpeningState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingOpeningRoll(tiedRoll: try DiceRoll(die1: 4, die2: 4))
+            )
+        )
         let resignationState = MatchState(
             config: .tournament(targetScore: 5),
             game: GameState(
@@ -77,7 +84,7 @@ struct SerializationTests {
             )
         )
 
-        for state in [openingState, rollState, resignationState, gameOverState] {
+        for state in [openingState, tiedOpeningState, rollState, resignationState, gameOverState] {
             let data = try JSONEncoder().encode(state)
             let decoded = try JSONDecoder().decode(MatchState.self, from: data)
 

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SheshBeshGame
+import Testing
+
+@Suite("Serialization")
+struct SerializationTests {
+    @Test("Match state round-trips through Codable")
+    func matchStateRoundTrip() throws {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            score: MatchScore(white: 2, black: 1),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingCubeResponse(
+                    CubeOffer(offeredBy: .white, proposedValue: 4, previousCubeValue: 2)
+                ),
+                cube: CubeState(value: 2, owner: .black)
+            ),
+            gameNumber: 4,
+            crawfordState: .completed
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(MatchState.self, from: data)
+
+        #expect(decoded == state)
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
@@ -25,4 +25,27 @@ struct SerializationTests {
 
         #expect(decoded == state)
     }
+
+    @Test("Match state round-trips while a turn is in progress")
+    func awaitingMoveRoundTripPreservesRemainingDice() throws {
+        let state = try makeMatch(
+            board: .initial(),
+            player: .black,
+            dice: [6, 3],
+            config: .tournament(targetScore: 7),
+            score: MatchScore(white: 3, black: 2),
+            cube: CubeState(value: 2, owner: .white)
+        )
+
+        let data = try JSONEncoder().encode(state)
+        let decoded = try JSONDecoder().decode(MatchState.self, from: data)
+
+        #expect(decoded == state)
+        guard case .awaitingMove(let turn) = decoded.game.phase else {
+            Issue.record("Expected awaitingMove phase after decoding")
+            return
+        }
+        #expect(turn.player == .black)
+        #expect(turn.remainingDice == [6, 3])
+    }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
@@ -48,4 +48,69 @@ struct SerializationTests {
         #expect(turn.player == .black)
         #expect(turn.remainingDice == [6, 3])
     }
+
+    @Test("Match state round-trips remaining game phases")
+    func remainingGamePhasesRoundTrip() throws {
+        let rollState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let openingState = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+        let resignationState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingResignationResponse(
+                    ResignationOffer(
+                        offeredBy: .black,
+                        winKind: .gammon,
+                        resumePhase: .awaitingRoll(.black)
+                    )
+                )
+            )
+        )
+        let gameOverState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 2))
+            )
+        )
+
+        for state in [openingState, rollState, resignationState, gameOverState] {
+            let data = try JSONEncoder().encode(state)
+            let decoded = try JSONDecoder().decode(MatchState.self, from: data)
+
+            #expect(decoded == state)
+        }
+    }
+
+    @Test("Match state round-trips completion and Crawford states")
+    func completionAndCrawfordStatesRoundTrip() throws {
+        for crawfordState in [
+            CrawfordState.notReached,
+            .availableNextGame,
+            .active,
+            .completed,
+        ] {
+            let state = MatchState(
+                config: .tournament(targetScore: 5),
+                score: MatchScore(white: 5, black: 3),
+                game: GameState(
+                    board: .initial(),
+                    phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 1))
+                ),
+                gameNumber: 6,
+                crawfordState: crawfordState,
+                completion: MatchCompletion(winner: .white, finalScore: MatchScore(white: 5, black: 3))
+            )
+
+            let data = try JSONEncoder().encode(state)
+            let decoded = try JSONDecoder().decode(MatchState.self, from: data)
+
+            #expect(decoded == state)
+            #expect(decoded.completion == state.completion)
+            #expect(decoded.crawfordState == crawfordState)
+        }
+    }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/TestSupport.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/TestSupport.swift
@@ -1,0 +1,59 @@
+import SheshBeshGame
+import Testing
+
+final class ScriptedDiceRoller: DiceRolling, @unchecked Sendable {
+    private let values: [Int]
+    private var index = 0
+
+    init(_ values: [Int]) {
+        self.values = values
+    }
+
+    func rollDie() -> Int {
+        guard !values.isEmpty else { return 1 }
+        let value = values[index % values.count]
+        index += 1
+        return value
+    }
+}
+
+func point(_ rawValue: Int) -> PointID {
+    PointID(rawValue: rawValue)!
+}
+
+func makeGame(
+    board: Board,
+    player: Player,
+    dice: [Int],
+    cube: CubeState = CubeState(),
+    isCrawford: Bool = false
+) throws -> GameState {
+    let roll = try DiceRoll(die1: dice[0], die2: dice.count > 1 ? dice[1] : dice[0])
+    return GameState(
+        board: board,
+        phase: .awaitingMove(TurnState(player: player, roll: roll, remainingDice: dice)),
+        cube: cube,
+        isCrawford: isCrawford
+    )
+}
+
+func makeMatch(
+    board: Board,
+    player: Player,
+    dice: [Int],
+    config: MatchConfig = .tournament(targetScore: 5),
+    score: MatchScore = MatchScore(),
+    cube: CubeState = CubeState()
+) throws -> MatchState {
+    MatchState(
+        config: config,
+        score: score,
+        game: try makeGame(board: board, player: player, dice: dice, cube: cube)
+    )
+}
+
+func expectNoMixedPoints(_ board: Board) {
+    for state in board.points {
+        #expect((state.owner == nil) == (state.count == 0))
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/TestSupport.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/TestSupport.swift
@@ -57,3 +57,54 @@ func expectNoMixedPoints(_ board: Board) {
         #expect((state.owner == nil) == (state.count == 0))
     }
 }
+
+func playFirstLegalMovesUntilRoll(
+    from state: MatchState,
+    using engine: MatchEngine,
+    limit: Int = 4
+) throws -> MatchState {
+    var next = state
+    for _ in 0..<limit {
+        guard case .awaitingMove(let turn) = next.game.phase else { return next }
+        let move = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: next.game).first)
+        next = try engine.apply(action: .move(move), to: next)
+    }
+    return next
+}
+
+func expectInvalidAction(_ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected MatchEngineError.invalidAction")
+    } catch let error as MatchEngineError {
+        guard case .invalidAction(let message) = error else {
+            Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+            return
+        }
+        #expect(!message.isEmpty)
+    } catch {
+        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+    }
+}
+
+func expectMatchEngineError(_ expected: MatchEngineError, _ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected \(expected)")
+    } catch let error as MatchEngineError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Expected \(expected), got \(error)")
+    }
+}
+
+func expectBoardError(_ expected: BoardError, _ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected \(expected)")
+    } catch let error as BoardError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Expected \(expected), got \(error)")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ if let moveAction = legalActions.first(where: {
 ```
 
 `MatchEngine.legalActions(in:)` is the safest source of UI actions. It exposes
-rolls, cube decisions, resignations, next-game transitions, and legal checker
-moves for the current phase.
+rolls, cube decisions, resignations, next-game transitions, legal checker moves,
+and explicit pass actions for blocked turns.
 
 ## SwiftUI View Model Example
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ rules engine that can be embedded in a future SwiftUI mobile app.
 
 ```text
 shesh-besh/
+  Package.swift              # repo-root entry point for swift build/test
   Packages/
     SheshBeshGame/
       Package.swift
@@ -29,11 +30,15 @@ shesh-besh/
 The game engine is intentionally isolated as a local Swift package so the app
 UI can depend on it without mixing presentation code into the rules layer.
 
-## Running Tests
+## Building and Running Tests
 
 ```sh
-swift test --package-path Packages/SheshBeshGame --enable-swift-testing
+swift build
+swift test
 ```
+
+The nested package remains usable directly with `swift build --package-path
+Packages/SheshBeshGame` and `swift test --package-path Packages/SheshBeshGame`.
 
 ## What The Engine Implements
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,241 @@
 # Shesh Besh
 
-An iOS backgammon game.
+An iOS backgammon game repo. The current implementation is a UI-free Swift
+rules engine that can be embedded in a future SwiftUI mobile app.
 
 ## Requirements
 
-- Xcode 15+
+- Xcode 26.4+
+- Apple Swift 6.3+
 - iOS 17+
-- Swift 5.9+
+- Swift Testing
 
-## Getting started
+## Repository Layout
 
-```sh
-open SheshBesh.xcodeproj
+```text
+shesh-besh/
+  Packages/
+    SheshBeshGame/
+      Package.swift
+      Sources/SheshBeshGame/
+      Tests/SheshBeshGameTests/
+
+  SheshBesh.xcodeproj      # future SwiftUI app project
+  SheshBesh/               # future app target
+  SheshBeshTests/          # future app-level tests
+  SheshBeshUITests/        # future UI tests
 ```
 
-Build and run from Xcode (⌘R).
+The game engine is intentionally isolated as a local Swift package so the app
+UI can depend on it without mixing presentation code into the rules layer.
 
-## Project layout
+## Running Tests
 
-TBD — source will live under `SheshBesh/` once the Xcode project is created.
+```sh
+swift test --package-path Packages/SheshBeshGame --enable-swift-testing
+```
+
+## What The Engine Implements
+
+`SheshBeshGame` implements standard tournament match backgammon:
+
+- standard initial board setup
+- opening roll with reroll on ties
+- legal checker movement
+- bar entry before other moves
+- blocked points and hits
+- doubles as four playable moves
+- maximum dice usage
+- higher-die rule when only one die can be played
+- bearing off, including oversize bear-off
+- automatic pass when no legal move exists
+- single, gammon, and backgammon wins
+- doubling cube offers, takes, drops, ownership, and redoubles
+- Crawford game handling
+- resignation offers for single/gammon/backgammon
+- match scoring and match completion
+
+White moves from point `24` toward point `1`. Black moves from point `1`
+toward point `24`.
+
+## Core Types
+
+Import the engine from app code with:
+
+```swift
+import SheshBeshGame
+```
+
+The main public value types are:
+
+- `MatchState`: complete match state, including score, game, Crawford status,
+  and completion.
+- `GameState`: current board, phase, cube, and Crawford flag.
+- `Board`: points, bar counts, and borne-off counts.
+- `PointID`: validated point identifier from `1...24`.
+- `Player`: `.white` or `.black`.
+- `DiceRoll`: two dice plus playable dice expansion for doubles.
+- `Move` and `MoveSequence`: checker moves and generated legal sequences.
+- `CubeState`: cube value and owner.
+- `MatchConfig`: match target and rule toggles.
+- `MatchAction`: reducer action applied through `MatchEngine`.
+
+State models are value types and support `Codable`, `Equatable`, and `Sendable`
+where appropriate.
+
+## Basic Usage
+
+Create a match and apply actions through `MatchEngine`:
+
+```swift
+import SheshBeshGame
+
+let engine = MatchEngine()
+var state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+
+state = try engine.apply(action: .rollOpeningDice, to: state)
+
+let legalActions = MatchEngine.legalActions(in: state)
+if let moveAction = legalActions.first(where: {
+    if case .move = $0 { true } else { false }
+}) {
+    state = try engine.apply(action: moveAction, to: state)
+}
+```
+
+`MatchEngine.legalActions(in:)` is the safest source of UI actions. It exposes
+rolls, cube decisions, resignations, next-game transitions, and legal checker
+moves for the current phase.
+
+## SwiftUI View Model Example
+
+The package contains no SwiftUI code, but it is designed to sit behind a small
+observable model:
+
+```swift
+import Observation
+import SheshBeshGame
+
+@MainActor
+@Observable
+final class MatchViewModel {
+    private let engine: MatchEngine
+
+    var state: MatchState
+    var lastError: String?
+
+    init(
+        engine: MatchEngine = MatchEngine(),
+        config: MatchConfig = .tournament(targetScore: 5)
+    ) {
+        self.engine = engine
+        self.state = MatchEngine.newMatch(config: config)
+    }
+
+    var legalActions: [MatchAction] {
+        MatchEngine.legalActions(in: state)
+    }
+
+    func send(_ action: MatchAction) {
+        do {
+            state = try engine.apply(action: action, to: state)
+            lastError = nil
+        } catch {
+            lastError = String(describing: error)
+        }
+    }
+}
+```
+
+Views can bind buttons, taps, and alerts to `send(_:)` while rendering directly
+from `state`.
+
+## Rendering Board State
+
+`Board` is UI-agnostic. A SwiftUI board can map points however it likes:
+
+```swift
+let board = viewModel.state.game.board
+let pointID = PointID(rawValue: 24)!
+let point = board.point(pointID)
+
+switch point.owner {
+case .white:
+    // render point.count white checkers
+case .black:
+    // render point.count black checkers
+case nil:
+    // render an empty point
+}
+```
+
+Useful board queries:
+
+```swift
+board.barCount(for: .white)
+board.borneOffCount(for: .black)
+board.occupiedPoints(for: .white)
+board.totalCheckers(for: .black)
+```
+
+To render possible checker destinations for a selected source, ask the reducer
+for legal move actions and filter the moves:
+
+```swift
+let legalMoves: [Move] = MatchEngine.legalActions(in: viewModel.state).compactMap {
+    if case .move(let move) = $0 { move } else { nil }
+}
+```
+
+## Persistence
+
+`MatchState` is `Codable`, so the app can save and restore snapshots:
+
+```swift
+let data = try JSONEncoder().encode(viewModel.state)
+let restored = try JSONDecoder().decode(MatchState.self, from: data)
+```
+
+The package does not choose a persistence store. The future app can put encoded
+state in a file, SwiftData, CloudKit, or a multiplayer transport.
+
+## Deterministic Dice In Tests
+
+Production `MatchEngine()` uses `SystemDiceRoller`. Tests can inject a scripted
+roller:
+
+```swift
+final class ScriptedDiceRoller: DiceRolling, @unchecked Sendable {
+    private let values: [Int]
+    private var index = 0
+
+    init(_ values: [Int]) {
+        self.values = values
+    }
+
+    func rollDie() -> Int {
+        let value = values[index % values.count]
+        index += 1
+        return value
+    }
+}
+
+let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 2, 3, 1]))
+```
+
+This keeps reducer tests deterministic without baking test-only behavior into
+the engine.
+
+## Non-Goals For This Package
+
+The engine does not include:
+
+- SwiftUI, UIKit, or board rendering
+- GameKit or networking
+- CloudKit or local persistence stores
+- animations, gestures, sounds, or haptics
+- AI opponents
+- commit-reveal dice
+- money-game-only rules such as Jacoby or beavers
+
+Commit-reveal dice is tracked as a post-V1 item in `TODOS.md`.


### PR DESCRIPTION
## Summary
- Add a local Swift 6.1 package under `Packages/SheshBeshGame` for the backgammon rules engine
- Implement board state, legal move generation, match flow, cube handling, Crawford logic, resignations, and scoring
- Add Swift Testing coverage for core rules, invariants, serialization, and match progression
- Update the root README with SwiftUI integration guidance for future app use

## Testing
- `swift test --package-path Packages/SheshBeshGame --enable-swift-testing`
- Added unit and invariant tests covering move legality, bearing off, cube ownership, Crawford behavior, and Codable round-trips