### PR TITLE
Add regression tests for forced-die rules, resignation flow, scoring, and board totals

### DIFF
--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -39,4 +39,21 @@ struct BoardTests {
         #expect(board.barCount(for: .white) == 1)
         #expect(board.totalCheckers(for: .white) == 15)
     }
+
+    @Test("Hitting from the bar preserves both players' total checker counts")
+    func totalsRemainFifteenAfterBarHit() throws {
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(22), owner: .black, count: 1)
+        try board.setBorneOff(for: .black, count: 14)
+
+        try board.apply(Move(player: .white, source: .bar, destination: .point(point(22)), die: 3))
+
+        #expect(board.point(point(22)) == PointState(owner: .white, count: 1))
+        #expect(board.barCount(for: .white) == 0)
+        #expect(board.barCount(for: .black) == 1)
+        #expect(board.totalCheckers(for: .white) == 15)
+        #expect(board.totalCheckers(for: .black) == 15)
+    }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -180,6 +180,23 @@ struct MatchEngineTests {
         #expect(state.game.phase == .awaitingRoll(.white))
     }
 
+    @Test("Rejected resignation restores awaitingMove turns")
+    func rejectedResignationResumesAwaitingMove() throws {
+        let engine = MatchEngine()
+        let board = Board.initial()
+        var state = try makeMatch(board: board, player: .white, dice: [4, 1])
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .rejectResignation(.black), to: state)
+
+        guard case .awaitingMove(let turn) = state.game.phase else {
+            Issue.record("Expected awaitingMove after resignation rejection")
+            return
+        }
+        #expect(turn.player == .white)
+        #expect(turn.remainingDice == [4, 1])
+    }
+
     @Test("Bearing off the last checker classifies backgammon")
     func bearingOffLastCheckerEndsGame() throws {
         var board = Board.empty()
@@ -260,6 +277,22 @@ struct MatchEngineTests {
 
         #expect(state.completion == MatchCompletion(winner: .black, finalScore: state.score))
         #expect(MatchEngine.legalActions(in: state).isEmpty)
+    }
+
+    @Test("Match completion is recorded when points exceed targetScore")
+    func matchCompletionWhenScoreExceedsTarget() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 3),
+            score: MatchScore(white: 0, black: 2),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .gammon), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 4)
+        #expect(state.completion == MatchCompletion(winner: .black, finalScore: state.score))
     }
 
     @Test("A player who is one point away triggers Crawford for the next game")

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
@@ -62,6 +62,19 @@ struct MoveValidatorTests {
         ])
     }
 
+    @Test("Higher die remains forced when only one checker can enter from a stacked bar")
+    func higherDieRuleWithMultipleBarCheckers() throws {
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 2)
+        try board.setPoint(point(24), owner: .black, count: 2)
+
+        let firstMoves = MoveValidator.legalFirstMoves(for: .white, board: board, dice: [1, 2])
+
+        #expect(firstMoves == [
+            Move(player: .white, source: .bar, destination: .point(point(23)), die: 2),
+        ])
+    }
+
     @Test("Oversize bear-off requires no checker farther from home")
     func oversizeBearOff() throws {
         var blocked = Board.empty()
@@ -105,6 +118,17 @@ struct MoveValidatorTests {
         #expect(sequences.allSatisfy { $0.moves.count == 4 })
     }
 
+    @Test("Doubles force the maximum available count even when fewer than four can be played")
+    func doublesUseMaximumAvailableCountWhenPartial() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 2)
+
+        let sequences = MoveValidator.legalMoves(for: .white, board: board, dice: [6, 6, 6, 6])
+
+        #expect(!sequences.isEmpty)
+        #expect(sequences.allSatisfy { $0.moves.count == 2 })
+    }
+
     @Test("Black moves upward and bears off from the high board")
     func blackMovementAndBearOff() throws {
         var board = Board.empty()
@@ -132,6 +156,24 @@ struct MoveValidatorTests {
 
         #expect(firstMoves == [
             Move(player: .black, source: .bar, destination: .point(point(4)), die: 4),
+        ])
+    }
+
+    @Test("Black oversize bear-off uses point 19 before point 20")
+    func blackOversizeBearOffPrefersFartherChecker() throws {
+        var board = Board.empty()
+        try board.setPoint(point(20), owner: .black, count: 1)
+        try board.setPoint(point(19), owner: .black, count: 1)
+
+        let blockedOversize = MoveValidator.legalFirstMoves(for: .black, board: board, dice: [6])
+        #expect(blockedOversize == [
+            Move(player: .black, source: .point(point(19)), destination: .off, die: 6),
+        ])
+
+        try board.setPoint(point(19), owner: nil, count: 0)
+        let allowedOversize = MoveValidator.legalFirstMoves(for: .black, board: board, dice: [6])
+        #expect(allowedOversize == [
+            Move(player: .black, source: .point(point(20)), destination: .off, die: 6),
         ])
     }
 }


### PR DESCRIPTION
### Motivation
- Capture regressions around move selection rules (forced higher die and partial doubles), resignation handling while awaiting a move, match completion conditions when awarded points exceed the target, and board invariants after hits.

### Description
- Added new tests in `Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift` to validate the higher-die rule with multiple bar checkers, enforce maximum available moves for partial doubles, and verify black oversize bear-off preference between points 19 and 20.
- Added tests in `Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift` to ensure a rejected resignation restores an `awaitingMove` turn state and that match completion is recorded when awarded points exceed `targetScore`.
- Added a `Board` test in `Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift` to assert both players have `15` total checkers after a hit from the bar.

### Testing
- Ran `swift test` in `Packages/SheshBeshGame`, which failed due to the environment Swift tools mismatch (package requires tools version `6.3.0` while installed is `6.1.3`).
- No other automated test runs were possible in this environment due to the toolchain mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ecfa986d2c832a9bf7cd9542780dfd)