### PR TITLE
Tighten game engine test coverage

### DIFF
--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardInternalTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardInternalTests.swift
@@ -1,0 +1,27 @@
+@testable import SheshBeshGame
+import Testing
+
+@Suite("Board internal mutations")
+struct BoardInternalTests {
+    @Test("Applying a move rejects missing source checkers")
+    func applyRejectsNoCheckerAtSource() {
+        var board = Board.empty()
+        let move = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        expectBoardError(.noCheckerAtSource) {
+            try board.apply(move)
+        }
+    }
+
+    @Test("Applying a move rejects blocked destinations")
+    func applyRejectsBlockedDestination() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setPoint(point(5), owner: .black, count: 2)
+        let move = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        expectBoardError(.blockedDestination) {
+            try board.apply(move)
+        }
+    }
+}

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -1,8 +1,16 @@
+import Foundation
 import SheshBeshGame
 import Testing
 
 @Suite("Board")
 struct BoardTests {
+    @Test("Point IDs reject values outside the board")
+    func pointIDRejectsOutOfRangeRawValues() {
+        #expect(PointID(rawValue: 0) == nil)
+        #expect(PointID(rawValue: 25) == nil)
+        #expect(PointID(rawValue: -1) == nil)
+    }
+
     @Test("Initial board has standard checker placement")
     func initialBoardPlacement() {
         let board = Board.initial()
@@ -87,15 +95,60 @@ struct BoardTests {
             _ = try Board(points: points, blackBorneOff: -1)
         }
     }
-}
 
-private func expectBoardError(_ expected: BoardError, _ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected \(expected)")
-    } catch let error as BoardError {
-        #expect(error == expected)
-    } catch {
-        Issue.record("Expected \(expected), got \(error)")
+    @Test("Set point rejects mismatched owner and count")
+    func setPointRejectsInvalidOccupancy() throws {
+        var board = Board.empty()
+
+        expectBoardError(.invalidPointOccupancy) {
+            try board.setPoint(point(1), owner: nil, count: 1)
+        }
+        expectBoardError(.invalidPointOccupancy) {
+            try board.setPoint(point(1), owner: .white, count: 0)
+        }
+    }
+
+    @Test("Game validity rejects malformed checker totals")
+    func isValidForGameRejectsWrongTotals() throws {
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 14)
+        try board.setPoint(point(24), owner: .black, count: 15)
+
+        #expect(!board.isValidForGame())
+    }
+
+    @Test("Game validity rejects malformed point ownership")
+    func isValidForGameRejectsInvalidPointOccupancy() throws {
+        let pointsJSON = ([#"{"owner":"white","count":0}"#] + Array(repeating: #"{"count":0}"#, count: 23))
+            .joined(separator: ",")
+        let json = """
+        {
+          "points": [\(pointsJSON)],
+          "whiteBar": 0,
+          "blackBar": 0,
+          "whiteBorneOff": 15,
+          "blackBorneOff": 15
+        }
+        """
+        let board = try JSONDecoder().decode(Board.self, from: Data(json.utf8))
+
+        #expect(!board.isValidForGame())
+    }
+
+    @Test("Game validity rejects negative decoded counts")
+    func isValidForGameRejectsNegativeCounts() throws {
+        let pointsJSON = Array(repeating: #"{"count":0}"#, count: 24).joined(separator: ",")
+        let json = """
+        {
+          "points": [\(pointsJSON)],
+          "whiteBar": -1,
+          "blackBar": 0,
+          "whiteBorneOff": 15,
+          "blackBorneOff": 15
+        }
+        """
+        let board = try JSONDecoder().decode(Board.self, from: Data(json.utf8))
+
+        #expect(!board.isValidForGame())
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
@@ -11,6 +11,10 @@ struct InvariantTests {
         ]
         let engine = MatchEngine(diceRoller: ScriptedDiceRoller(dice))
         var state = MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        var offeredDouble = false
+        var handledCubeResponse = false
+        var offeredResignation = false
+        var handledResignationResponse = false
 
         for _ in 0..<80 {
             let action: MatchAction
@@ -18,13 +22,25 @@ struct InvariantTests {
             case .awaitingOpeningRoll:
                 action = .rollOpeningDice
             case .awaitingRoll(let player):
-                action = .rollDice(player)
+                if !offeredDouble, MatchEngine.legalActions(in: state).contains(.offerDouble(player)) {
+                    offeredDouble = true
+                    action = .offerDouble(player)
+                } else {
+                    action = .rollDice(player)
+                }
             case .awaitingMove(let turn):
-                let firstMove = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: state.game).first)
-                action = .move(firstMove)
+                if !offeredResignation {
+                    offeredResignation = true
+                    action = .offerResignation(turn.player, .single)
+                } else {
+                    let firstMove = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: state.game).first)
+                    action = .move(firstMove)
+                }
             case .awaitingCubeResponse(let offer):
+                handledCubeResponse = true
                 action = .takeDouble(offer.offeredBy.opponent)
             case .awaitingResignationResponse(let offer):
+                handledResignationResponse = true
                 action = .rejectResignation(offer.offeredBy.opponent)
             case .gameOver:
                 if state.completion != nil { return }
@@ -39,5 +55,10 @@ struct InvariantTests {
             #expect(state.score.score(for: .white) >= 0)
             #expect(state.score.score(for: .black) >= 0)
         }
+
+        #expect(offeredDouble)
+        #expect(handledCubeResponse)
+        #expect(offeredResignation)
+        #expect(handledResignationResponse)
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
@@ -3,6 +3,16 @@ import Testing
 
 @Suite("Match engine errors")
 struct MatchEngineErrorTests {
+    @Test("Dice roll initializer rejects invalid dice values")
+    func diceRollInitializerRejectsInvalidValues() {
+        expectMatchEngineError(.invalidDiceValue) {
+            _ = try DiceRoll(die1: 0, die2: 4)
+        }
+        expectMatchEngineError(.invalidDiceValue) {
+            _ = try DiceRoll(die1: 3, die2: 7)
+        }
+    }
+
     @Test("Opening roll rejects invalid dice values")
     func openingRollRejectsInvalidDiceValues() {
         let engine = MatchEngine(diceRoller: ScriptedDiceRoller([0, 4]))
@@ -33,7 +43,7 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rollOpeningDice, to: state)
         }
     }
@@ -45,7 +55,7 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rollDice(.black), to: state)
         }
     }
@@ -54,7 +64,7 @@ struct MatchEngineErrorTests {
     func rollDuringMovePhaseThrowsInvalidAction() throws {
         let state = try makeMatch(board: .initial(), player: .white, dice: [4, 1])
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rollDice(.white), to: state)
         }
     }
@@ -67,7 +77,7 @@ struct MatchEngineErrorTests {
         )
         let move = Move(player: .white, source: .point(point(24)), destination: .point(point(21)), die: 3)
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .move(move), to: state)
         }
     }
@@ -99,10 +109,10 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .takeDouble(.black), to: state)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .dropDouble(.black), to: state)
         }
     }
@@ -116,10 +126,10 @@ struct MatchEngineErrorTests {
         )
         let offered = try engine.apply(action: .offerDouble(.white), to: state)
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .takeDouble(.white), to: offered)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .dropDouble(.white), to: offered)
         }
     }
@@ -135,7 +145,7 @@ struct MatchEngineErrorTests {
             )
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .offerDouble(.white), to: state)
         }
     }
@@ -144,7 +154,7 @@ struct MatchEngineErrorTests {
     func resignationOfferOutsidePlayablePhaseThrowsInvalidAction() {
         let state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .offerResignation(.white, .single), to: state)
         }
     }
@@ -156,10 +166,10 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .acceptResignation(.black), to: state)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .rejectResignation(.black), to: state)
         }
     }
@@ -173,10 +183,10 @@ struct MatchEngineErrorTests {
         )
         let offered = try engine.apply(action: .offerResignation(.white, .single), to: state)
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .acceptResignation(.white), to: offered)
         }
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try engine.apply(action: .rejectResignation(.white), to: offered)
         }
     }
@@ -188,7 +198,7 @@ struct MatchEngineErrorTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
 
-        expectInvalidMatchAction {
+        expectInvalidAction {
             _ = try MatchEngine().apply(action: .startNextGame, to: state)
         }
     }
@@ -211,31 +221,5 @@ struct MatchEngineErrorTests {
         expectMatchEngineError(.matchAlreadyCompleted) {
             _ = try MatchEngine().apply(action: .startNextGame, to: state)
         }
-    }
-}
-
-private func expectInvalidMatchAction(_ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected MatchEngineError.invalidAction")
-    } catch let error as MatchEngineError {
-        guard case .invalidAction(let message) = error else {
-            Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
-            return
-        }
-        #expect(!message.isEmpty)
-    } catch {
-        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
-    }
-}
-
-private func expectMatchEngineError(_ expected: MatchEngineError, _ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected \(expected)")
-    } catch let error as MatchEngineError {
-        #expect(error == expected)
-    } catch {
-        Issue.record("Expected \(expected), got \(error)")
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -64,6 +64,7 @@ struct MatchEngineTests {
 
         #expect(state.game.board.point(point(1)) == PointState(owner: .white, count: 1))
         #expect(state.game.board.point(point(4)) == .empty)
+        #expect(state.game.board.barCount(for: .white) == 0)
         #expect(state.game.board.barCount(for: .black) == 1)
         #expect(state.game.phase == .awaitingRoll(.black))
     }
@@ -84,7 +85,60 @@ struct MatchEngineTests {
         )
         let next = try engine.apply(action: .rollDice(.white), to: state)
 
+        #expect(next.game.board == board)
         #expect(next.game.phase == .awaitingRoll(.black))
+    }
+
+    @Test("Legal actions at roll time are exactly roll, double, and resignations")
+    func legalActionsAtRollTimeArePinned() {
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        #expect(MatchEngine.legalActions(in: state) == [
+            .offerDouble(.white),
+            .rollDice(.white),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+    }
+
+    @Test("Legal actions at move time are exactly legal first moves and resignations")
+    func legalActionsAtMoveTimeArePinned() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(19), owner: .black, count: 15)
+
+        let state = try makeMatch(board: board, player: .white, dice: [1])
+        let checkerMove = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        #expect(MatchEngine.legalActions(in: state) == [
+            .move(checkerMove),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+    }
+
+    @Test("Disabling the doubling cube removes double offers")
+    func disablingDoublingCubeRemovesDoubleOffers() {
+        let state = MatchState(
+            config: MatchConfig(targetScore: 5, usesDoublingCube: false),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        #expect(MatchEngine.legalActions(in: state) == [
+            .rollDice(.white),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+        expectInvalidAction {
+            _ = try MatchEngine().apply(action: .offerDouble(.white), to: state)
+        }
     }
 
     @Test("Double take assigns cube ownership to the taker")
@@ -127,7 +181,7 @@ struct MatchEngineTests {
 
     @Test("Only the cube owner can redouble after a take")
     func onlyCubeOwnerCanRedouble() throws {
-        let engine = MatchEngine()
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1]))
         var state = MatchState(
             config: .tournament(targetScore: 5),
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
@@ -138,7 +192,10 @@ struct MatchEngineTests {
 
         #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
 
-        state.game.phase = .awaitingRoll(.black)
+        state = try engine.apply(action: .rollDice(.white), to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
+
+        #expect(state.game.phase == .awaitingRoll(.black))
         #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
@@ -181,11 +238,11 @@ struct MatchEngineTests {
 
     @Test("Crawford game disables the cube and is marked completed after the game")
     func crawfordGame() throws {
-        let engine = MatchEngine()
-        let previousResult = GameResult(winner: .white, winKind: .single, cubeValue: 1)
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 6, 1]))
+        let previousResult = GameResult(winner: .black, winKind: .single, cubeValue: 1)
         var state = MatchState(
             config: .tournament(targetScore: 3),
-            score: MatchScore(white: 2, black: 0),
+            score: MatchScore(white: 0, black: 2),
             game: GameState(board: .initial(), phase: .gameOver(previousResult)),
             crawfordState: .availableNextGame
         )
@@ -193,27 +250,29 @@ struct MatchEngineTests {
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.game.isCrawford)
 
-        state.game.phase = .awaitingRoll(.white)
-        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
 
-        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
-        state = try engine.apply(action: .acceptResignation(.black), to: state)
+        state = try engine.apply(action: .offerResignation(.black, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.white), to: state)
 
         #expect(state.crawfordState == .completed)
 
         state = try engine.apply(action: .startNextGame, to: state)
-        state.game.phase = .awaitingRoll(.white)
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
         #expect(!state.game.isCrawford)
-        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
     @Test("The doubling cube is available again after the Crawford game")
     func cubeAvailableAfterCrawfordGameCompletes() throws {
-        let engine = MatchEngine()
-        let previousResult = GameResult(winner: .white, winKind: .single, cubeValue: 1)
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 6, 1]))
+        let previousResult = GameResult(winner: .black, winKind: .single, cubeValue: 1)
         var state = MatchState(
             config: .tournament(targetScore: 4),
-            score: MatchScore(white: 3, black: 0),
+            score: MatchScore(white: 0, black: 3),
             game: GameState(board: .initial(), phase: .gameOver(previousResult)),
             crawfordState: .availableNextGame
         )
@@ -221,18 +280,20 @@ struct MatchEngineTests {
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.game.isCrawford)
 
-        state.game.phase = .awaitingRoll(.white)
-        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
 
-        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
-        state = try engine.apply(action: .acceptResignation(.black), to: state)
+        state = try engine.apply(action: .offerResignation(.black, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.white), to: state)
         #expect(state.crawfordState == .completed)
 
         state = try engine.apply(action: .startNextGame, to: state)
-        state.game.phase = .awaitingRoll(.white)
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
 
         #expect(!state.game.isCrawford)
-        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
     @Test("Accepted resignation scores the offered result")
@@ -347,6 +408,7 @@ struct MatchEngineTests {
         let next = try MatchEngine().apply(action: .move(move), to: state)
 
         #expect(next.score.score(for: .white) == 3)
+        #expect(next.game.board.borneOffCount(for: .white) == 15)
         guard case .gameOver(let result) = next.game.phase else {
             Issue.record("Expected game over after final checker bears off")
             return
@@ -487,18 +549,100 @@ struct MatchEngineTests {
         #expect(state.score.score(for: .black) == 1)
         #expect(state.crawfordState == .availableNextGame)
     }
-}
 
-private func expectInvalidAction(_ body: () throws -> Void) {
-    do {
-        try body()
-        Issue.record("Expected invalid action")
-    } catch let error as MatchEngineError {
-        guard case .invalidAction = error else {
-            Issue.record("Expected invalid action, got \(error)")
-            return
-        }
-    } catch {
-        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+    @Test("Crawford stays unavailable when the rule is disabled")
+    func crawfordRuleDisabledKeepsStateNotReached() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: MatchConfig(targetScore: 3, usesCrawfordRule: false),
+            score: MatchScore(white: 0, black: 1),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 2)
+        #expect(state.crawfordState == .notReached)
+        #expect(state.completion == nil)
+    }
+
+    @Test("Crawford is queued when either player reaches one away")
+    func crawfordIsQueuedWhenEitherPlayerReachesOneAway() throws {
+        let engine = MatchEngine()
+        var state = MatchState(
+            config: .tournament(targetScore: 3),
+            score: MatchScore(white: 2, black: 1),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .white) == 2)
+        #expect(state.score.score(for: .black) == 2)
+        #expect(state.crawfordState == .availableNextGame)
+    }
+
+    @Test("Starting the next game increments gameNumber")
+    func startNextGameIncrementsGameNumber() throws {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 1))
+            ),
+            gameNumber: 3
+        )
+
+        let next = try engine.apply(action: .startNextGame, to: state)
+
+        #expect(next.gameNumber == 4)
+        #expect(next.game.phase == .awaitingOpeningRoll)
+    }
+
+    @Test("Bear-off can queue Crawford and continue to the post-Crawford game")
+    func bearOffQueuesCrawfordThenMatchContinuesAfterCrawford() throws {
+        let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 6, 1]))
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(7), owner: .black, count: 14)
+        try board.setBorneOff(for: .black, count: 1)
+
+        var state = try makeMatch(
+            board: board,
+            player: .white,
+            dice: [1],
+            config: .tournament(targetScore: 4),
+            score: MatchScore(white: 2, black: 0)
+        )
+
+        state = try engine.apply(
+            action: .move(Move(player: .white, source: .point(point(1)), destination: .off, die: 1)),
+            to: state
+        )
+
+        #expect(state.score.score(for: .white) == 3)
+        #expect(state.crawfordState == .availableNextGame)
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        #expect(state.gameNumber == 2)
+        #expect(state.game.phase == .awaitingOpeningRoll)
+        #expect(state.game.isCrawford)
+
+        state = try engine.apply(action: .rollOpeningDice, to: state)
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        state = try engine.apply(action: .acceptResignation(.black), to: state)
+
+        #expect(state.score.score(for: .black) == 1)
+        #expect(state.crawfordState == .completed)
+        #expect(state.completion == nil)
+
+        state = try engine.apply(action: .startNextGame, to: state)
+        #expect(state.gameNumber == 3)
+        #expect(!state.game.isCrawford)
+        #expect(state.game.phase == .awaitingOpeningRoll)
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MoveValidatorTests.swift
@@ -66,7 +66,12 @@ struct MoveValidatorTests {
             Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1),
             Move(player: .white, source: .point(point(5)), destination: .off, die: 6),
         ])))
-        #expect(sequences.allSatisfy { $0.moves.count == 2 })
+        #expect(sequences == [
+            MoveSequence(moves: [
+                Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1),
+                Move(player: .white, source: .point(point(5)), destination: .off, die: 6),
+            ]),
+        ])
     }
 
     @Test("When only one die can be played, the higher die is forced")
@@ -104,6 +109,7 @@ struct MoveValidatorTests {
         #expect(blockedMoves == [
             Move(player: .white, source: .point(point(6)), destination: .off, die: 6),
         ])
+        #expect(!blockedMoves.contains(Move(player: .white, source: .point(point(5)), destination: .off, die: 6)))
 
         var allowed = Board.empty()
         try allowed.setPoint(point(5), owner: .white, count: 1)
@@ -194,5 +200,16 @@ struct MoveValidatorTests {
         #expect(allowedOversize == [
             Move(player: .black, source: .point(point(20)), destination: .off, die: 6),
         ])
+    }
+
+    @Test("Game phase helpers return no moves outside the matching turn")
+    func gamePhaseHelpersRequireAwaitingMoveForPlayer() throws {
+        let awaitingRoll = GameState(board: .initial(), phase: .awaitingRoll(.white))
+        #expect(MoveValidator.legalMoves(for: .white, in: awaitingRoll).isEmpty)
+        #expect(MoveValidator.legalFirstMoves(for: .white, in: awaitingRoll).isEmpty)
+
+        let awaitingWhiteMove = try makeGame(board: .initial(), player: .white, dice: [3, 1])
+        #expect(MoveValidator.legalMoves(for: .black, in: awaitingWhiteMove).isEmpty)
+        #expect(MoveValidator.legalFirstMoves(for: .black, in: awaitingWhiteMove).isEmpty)
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
@@ -48,4 +48,69 @@ struct SerializationTests {
         #expect(turn.player == .black)
         #expect(turn.remainingDice == [6, 3])
     }
+
+    @Test("Match state round-trips remaining game phases")
+    func remainingGamePhasesRoundTrip() throws {
+        let rollState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let openingState = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+        let resignationState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingResignationResponse(
+                    ResignationOffer(
+                        offeredBy: .black,
+                        winKind: .gammon,
+                        resumePhase: .awaitingRoll(.black)
+                    )
+                )
+            )
+        )
+        let gameOverState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 2))
+            )
+        )
+
+        for state in [openingState, rollState, resignationState, gameOverState] {
+            let data = try JSONEncoder().encode(state)
+            let decoded = try JSONDecoder().decode(MatchState.self, from: data)
+
+            #expect(decoded == state)
+        }
+    }
+
+    @Test("Match state round-trips completion and Crawford states")
+    func completionAndCrawfordStatesRoundTrip() throws {
+        for crawfordState in [
+            CrawfordState.notReached,
+            .availableNextGame,
+            .active,
+            .completed,
+        ] {
+            let state = MatchState(
+                config: .tournament(targetScore: 5),
+                score: MatchScore(white: 5, black: 3),
+                game: GameState(
+                    board: .initial(),
+                    phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 1))
+                ),
+                gameNumber: 6,
+                crawfordState: crawfordState,
+                completion: MatchCompletion(winner: .white, finalScore: MatchScore(white: 5, black: 3))
+            )
+
+            let data = try JSONEncoder().encode(state)
+            let decoded = try JSONDecoder().decode(MatchState.self, from: data)
+
+            #expect(decoded == state)
+            #expect(decoded.completion == state.completion)
+            #expect(decoded.crawfordState == crawfordState)
+        }
+    }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/TestSupport.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/TestSupport.swift
@@ -57,3 +57,54 @@ func expectNoMixedPoints(_ board: Board) {
         #expect((state.owner == nil) == (state.count == 0))
     }
 }
+
+func playFirstLegalMovesUntilRoll(
+    from state: MatchState,
+    using engine: MatchEngine,
+    limit: Int = 4
+) throws -> MatchState {
+    var next = state
+    for _ in 0..<limit {
+        guard case .awaitingMove(let turn) = next.game.phase else { return next }
+        let move = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: next.game).first)
+        next = try engine.apply(action: .move(move), to: next)
+    }
+    return next
+}
+
+func expectInvalidAction(_ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected MatchEngineError.invalidAction")
+    } catch let error as MatchEngineError {
+        guard case .invalidAction(let message) = error else {
+            Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+            return
+        }
+        #expect(!message.isEmpty)
+    } catch {
+        Issue.record("Expected MatchEngineError.invalidAction, got \(error)")
+    }
+}
+
+func expectMatchEngineError(_ expected: MatchEngineError, _ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected \(expected)")
+    } catch let error as MatchEngineError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Expected \(expected), got \(error)")
+    }
+}
+
+func expectBoardError(_ expected: BoardError, _ body: () throws -> Void) {
+    do {
+        try body()
+        Issue.record("Expected \(expected)")
+    } catch let error as BoardError {
+        #expect(error == expected)
+    } catch {
+        Issue.record("Expected \(expected), got \(error)")
+    }
+}


### PR DESCRIPTION
Adds focused SheshBeshGame test coverage for cube and Crawford config toggles, dice and point validation, board validity failures, internal board mutation errors, and Codable phase/completion round trips. Pins legal action shapes for roll and move phases, strengthens invariant coverage for cube and resignation response phases, and adds a multi-game Crawford flow from bear-off through post-Crawford play. Reworks fragile redouble and Crawford tests to use scripted dice instead of direct phase mutation, and centralizes shared test error helpers. Verified with `swift test --package-path Packages/SheshBeshGame`.