### PR TITLE
test: cover offerDouble rejection during move phase

### DIFF
--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineErrorTests.swift
@@ -150,6 +150,15 @@ struct MatchEngineErrorTests {
         }
     }
 
+    @Test("Double offers are rejected during checker movement")
+    func doubleOfferDuringMovePhaseThrowsInvalidAction() throws {
+        let state = try makeMatch(board: .initial(), player: .white, dice: [4, 1])
+
+        expectInvalidAction {
+            _ = try MatchEngine().apply(action: .offerDouble(.white), to: state)
+        }
+    }
+
     @Test("Resignation offers are rejected outside roll and move phases")
     func resignationOfferOutsidePlayablePhaseThrowsInvalidAction() {
         let state = MatchEngine.newMatch(config: .tournament(targetScore: 5))


### PR DESCRIPTION
## Summary
- Adds a regression test asserting that `MatchEngine.apply(.offerDouble(player))` throws `MatchEngineError.invalidAction` when the phase is `.awaitingMove`.
- The reducer already enforces this via `canOfferDouble`'s phase guard at `MatchEngine.swift:290`; this test locks the behavior in so a future refactor can't silently regress it.

## Test plan
- [x] `swift test --package-path Packages/SheshBeshGame` (79 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)