### PR TITLE
Fix opening roll tie state

### DIFF
--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
@@ -78,7 +78,10 @@ public struct MatchEngine: Sendable {
         let whiteDie = try rollDie()
         let blackDie = try rollDie()
         guard whiteDie != blackDie else {
-            return state
+            let tiedRoll = DiceRoll(uncheckedDie1: whiteDie, die2: blackDie)
+            var next = state
+            next.game.phase = .awaitingOpeningRoll(tiedRoll: tiedRoll)
+            return next
         }
 
         let player: Player = whiteDie > blackDie ? .white : .black
@@ -225,7 +228,7 @@ public struct MatchEngine: Sendable {
         next.crawfordState = isCrawford ? .active : next.crawfordState
         next.game = GameState(
             board: .initial(),
-            phase: .awaitingOpeningRoll,
+            phase: .awaitingOpeningRoll(),
             cube: CubeState(),
             isCrawford: isCrawford
         )

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
@@ -152,7 +152,7 @@ public struct ResignationOffer: Codable, Equatable, Hashable, Sendable {
 }
 
 public enum GamePhase: Codable, Equatable, Hashable, Sendable {
-    case awaitingOpeningRoll
+    case awaitingOpeningRoll(tiedRoll: DiceRoll? = nil)
     case awaitingRoll(Player)
     case awaitingMove(TurnState)
     case awaitingCubeResponse(CubeOffer)
@@ -175,7 +175,7 @@ public struct GameState: Codable, Equatable, Hashable, Sendable {
 
     public init(
         board: Board = .initial(),
-        phase: GamePhase = .awaitingOpeningRoll,
+        phase: GamePhase = .awaitingOpeningRoll(),
         cube: CubeState = CubeState(),
         isCrawford: Bool = false
     ) {

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -8,8 +8,11 @@ struct MatchEngineTests {
         let engine = MatchEngine(diceRoller: ScriptedDiceRoller([3, 3, 6, 2]))
         var state = MatchEngine.newMatch(config: .tournament(targetScore: 5))
 
+        let initialState = state
         state = try engine.apply(action: .rollOpeningDice, to: state)
-        #expect(state.game.phase == .awaitingOpeningRoll)
+        let tiedRoll = try DiceRoll(die1: 3, die2: 3)
+        #expect(state != initialState)
+        #expect(state.game.phase == .awaitingOpeningRoll(tiedRoll: tiedRoll))
 
         state = try engine.apply(action: .rollOpeningDice, to: state)
         guard case .awaitingMove(let turn) = state.game.phase else {
@@ -599,7 +602,7 @@ struct MatchEngineTests {
         let next = try engine.apply(action: .startNextGame, to: state)
 
         #expect(next.gameNumber == 4)
-        #expect(next.game.phase == .awaitingOpeningRoll)
+        #expect(next.game.phase == .awaitingOpeningRoll())
     }
 
     @Test("Bear-off can queue Crawford and continue to the post-Crawford game")
@@ -629,7 +632,7 @@ struct MatchEngineTests {
 
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.gameNumber == 2)
-        #expect(state.game.phase == .awaitingOpeningRoll)
+        #expect(state.game.phase == .awaitingOpeningRoll())
         #expect(state.game.isCrawford)
 
         state = try engine.apply(action: .rollOpeningDice, to: state)
@@ -643,6 +646,6 @@ struct MatchEngineTests {
         state = try engine.apply(action: .startNextGame, to: state)
         #expect(state.gameNumber == 3)
         #expect(!state.game.isCrawford)
-        #expect(state.game.phase == .awaitingOpeningRoll)
+        #expect(state.game.phase == .awaitingOpeningRoll())
     }
 }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/SerializationTests.swift
@@ -56,6 +56,13 @@ struct SerializationTests {
             game: GameState(board: .initial(), phase: .awaitingRoll(.white))
         )
         let openingState = MatchEngine.newMatch(config: .tournament(targetScore: 5))
+        let tiedOpeningState = MatchState(
+            config: .tournament(targetScore: 5),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingOpeningRoll(tiedRoll: try DiceRoll(die1: 4, die2: 4))
+            )
+        )
         let resignationState = MatchState(
             config: .tournament(targetScore: 5),
             game: GameState(
@@ -77,7 +84,7 @@ struct SerializationTests {
             )
         )
 
-        for state in [openingState, rollState, resignationState, gameOverState] {
+        for state in [openingState, tiedOpeningState, rollState, resignationState, gameOverState] {
             let data = try JSONEncoder().encode(state)
             let decoded = try JSONDecoder().decode(MatchState.self, from: data)
 


### PR DESCRIPTION
## Summary
- Preserve tied opening rolls in GamePhase.awaitingOpeningRoll so reactive UIs can observe and display re-roll state.
- Keep opening tie retries legal while starting normal turns unchanged after a non-tie.
- Add regression coverage for state mutation and Codable round-trip of tied opening rolls.

## Tests
- swift test --package-path Packages/SheshBeshGame