### PR TITLE
Preserve blocked roll turns

### DIFF
--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
@@ -29,6 +29,9 @@ public struct MatchEngine: Sendable {
             return actions
         case .awaitingMove(let turn):
             var actions = MoveValidator.legalFirstMoves(for: turn.player, in: state.game).map(MatchAction.move)
+            if actions.isEmpty {
+                actions.append(.passTurn(turn.player))
+            }
             actions.append(contentsOf: resignationActions(for: turn.player))
             return actions
         case .awaitingCubeResponse(let offer):
@@ -54,6 +57,8 @@ public struct MatchEngine: Sendable {
             return try rollDice(for: player, in: state)
         case .move(let move):
             return try apply(move: move, to: state)
+        case .passTurn(let player):
+            return try passTurn(by: player, in: state)
         case .offerDouble(let player):
             return try offerDouble(by: player, in: state)
         case .takeDouble(let player):
@@ -124,11 +129,21 @@ public struct MatchEngine: Sendable {
         } else {
             let nextTurn = TurnState(player: turn.player, roll: turn.roll, remainingDice: remainingDice)
             next.game.phase = .awaitingMove(nextTurn)
-            if MoveValidator.legalMoves(for: turn.player, in: next.game).isEmpty {
-                next.game.phase = .awaitingRoll(turn.player.opponent)
-            }
         }
 
+        return next
+    }
+
+    private func passTurn(by player: Player, in state: MatchState) throws -> MatchState {
+        guard case .awaitingMove(let turn) = state.game.phase, turn.player == player else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) has no turn to pass.")
+        }
+        guard MoveValidator.legalMoves(for: player, in: state.game).isEmpty else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) still has legal moves.")
+        }
+
+        var next = state
+        next.game.phase = .awaitingRoll(player.opponent)
         return next
     }
 
@@ -243,9 +258,6 @@ public struct MatchEngine: Sendable {
         next.phase = .awaitingMove(
             TurnState(player: player, roll: roll, remainingDice: roll.playableDice)
         )
-        if MoveValidator.legalMoves(for: player, in: next).isEmpty {
-            next.phase = .awaitingRoll(player.opponent)
-        }
         return next
     }
 

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/State.swift
@@ -215,6 +215,7 @@ public enum MatchAction: Codable, Equatable, Hashable, Sendable {
     case rollOpeningDice
     case rollDice(Player)
     case move(Move)
+    case passTurn(Player)
     case offerDouble(Player)
     case takeDouble(Player)
     case dropDouble(Player)

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/InvariantTests.swift
@@ -33,8 +33,14 @@ struct InvariantTests {
                     offeredResignation = true
                     action = .offerResignation(turn.player, .single)
                 } else {
-                    let firstMove = try #require(MoveValidator.legalFirstMoves(for: turn.player, in: state.game).first)
-                    action = .move(firstMove)
+                    let legalActions = MatchEngine.legalActions(in: state)
+                    if let moveAction = legalActions.first(where: {
+                        if case .move = $0 { true } else { false }
+                    }) {
+                        action = moveAction
+                    } else {
+                        action = try #require(legalActions.first { $0 == .passTurn(turn.player) })
+                    }
                 }
             case .awaitingCubeResponse(let offer):
                 handledCubeResponse = true

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -69,8 +69,8 @@ struct MatchEngineTests {
         #expect(state.game.phase == .awaitingRoll(.black))
     }
 
-    @Test("A roll with no legal moves automatically passes the turn")
-    func automaticPass() throws {
+    @Test("A roll with no legal moves preserves the turn until passed")
+    func blockedRollPreservesDiceUntilPassed() throws {
         var board = Board.empty()
         try board.setBar(for: .white, count: 1)
         try board.setBorneOff(for: .white, count: 14)
@@ -86,7 +86,65 @@ struct MatchEngineTests {
         let next = try engine.apply(action: .rollDice(.white), to: state)
 
         #expect(next.game.board == board)
-        #expect(next.game.phase == .awaitingRoll(.black))
+        guard case .awaitingMove(let turn) = next.game.phase else {
+            Issue.record("Expected blocked roll to remain awaitingMove")
+            return
+        }
+        #expect(turn.player == .white)
+        #expect(turn.roll == (try DiceRoll(die1: 1, die2: 2)))
+        #expect(turn.remainingDice == [1, 2])
+        #expect(MatchEngine.legalActions(in: next) == [
+            .passTurn(.white),
+            .offerResignation(.white, .single),
+            .offerResignation(.white, .gammon),
+            .offerResignation(.white, .backgammon),
+        ])
+
+        let passed = try engine.apply(action: .passTurn(.white), to: next)
+        #expect(passed.game.board == board)
+        #expect(passed.game.phase == .awaitingRoll(.black))
+    }
+
+    @Test("Blocked remaining dice preserve the turn until passed")
+    func blockedRemainingDicePreserveTurnUntilPassed() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(4), owner: .black, count: 2)
+        try board.setBorneOff(for: .black, count: 13)
+
+        let engine = MatchEngine()
+        var state = try makeMatch(board: board, player: .white, dice: [1, 1, 1, 1])
+        let move = Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1)
+
+        state = try engine.apply(action: .move(move), to: state)
+
+        guard case .awaitingMove(let turn) = state.game.phase else {
+            Issue.record("Expected blocked remaining dice to remain awaitingMove")
+            return
+        }
+        #expect(turn.player == .white)
+        #expect(turn.roll == (try DiceRoll(die1: 1, die2: 1)))
+        #expect(turn.remainingDice == [1, 1, 1])
+        #expect(MatchEngine.legalActions(in: state).contains(.passTurn(.white)))
+
+        state = try engine.apply(action: .passTurn(.white), to: state)
+        #expect(state.game.phase == .awaitingRoll(.black))
+    }
+
+    @Test("A turn with legal moves cannot be passed")
+    func legalMoveTurnCannotBePassed() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setBorneOff(for: .white, count: 14)
+        try board.setPoint(point(19), owner: .black, count: 15)
+
+        let state = try makeMatch(board: board, player: .white, dice: [1])
+
+        #expect(!MatchEngine.legalActions(in: state).contains(.passTurn(.white)))
+        expectInvalidAction {
+            _ = try MatchEngine().apply(action: .passTurn(.white), to: state)
+        }
     }
 
     @Test("Legal actions at roll time are exactly roll, double, and resignations")

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ if let moveAction = legalActions.first(where: {
 ```
 
 `MatchEngine.legalActions(in:)` is the safest source of UI actions. It exposes
-rolls, cube decisions, resignations, next-game transitions, and legal checker
-moves for the current phase.
+rolls, cube decisions, resignations, next-game transitions, legal checker moves,
+and explicit pass actions for blocked turns.
 
 ## SwiftUI View Model Example
 


### PR DESCRIPTION
Adds an explicit passTurn action so blocked rolls remain visible in TurnState until the UI acknowledges the pass. Updates move handling to preserve blocked remaining dice instead of silently advancing to the opponent. Adds regression coverage for blocked rolls, blocked remaining dice, illegal pass attempts, and updates README guidance for UI actions.