### PR TITLE
Show next cube value on centered doubling cube

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -778,7 +778,8 @@ private struct CubeView: View {
     }
 
     private var label: String {
-        cube.owner == nil && cube.value == 1 ? "64" : "\(cube.value)"
+        let displayValue = cube.owner == nil && cube.value == 1 ? cube.value * 2 : cube.value
+        return "\(displayValue)"
     }
 }
 


### PR DESCRIPTION
## Summary
- Centered doubling cube now displays the next-double value (`cube.value * 2`) instead of the hardcoded `"64"`, so the UI tracks the underlying `CubeState` if its initial value ever changes.

## Test plan
- [ ] Launch the app and confirm the centered cube reads `2` at the start of a game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)