### PR TITLE
Route opponent turns and double offers to dedicated screens

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -3,11 +3,19 @@ import SwiftUI
 
 public struct BoardView: View {
     public let viewModel: MatchViewModel
+    private let isReadOnly: Bool
+    private let showsActionBar: Bool
 
     @State private var selectedSource: MoveSource?
 
-    public init(viewModel: MatchViewModel) {
+    public init(
+        viewModel: MatchViewModel,
+        isReadOnly: Bool = false,
+        showsActionBar: Bool = true
+    ) {
         self.viewModel = viewModel
+        self.isReadOnly = isReadOnly
+        self.showsActionBar = showsActionBar
     }
 
     public var body: some View {
@@ -21,6 +29,7 @@ public struct BoardView: View {
 
                 BoardSurface(
                     viewModel: viewModel,
+                    isReadOnly: isReadOnly,
                     selectedSource: selectedSource,
                     onPointTap: handlePointTap,
                     onBarTap: handleBarTap,
@@ -29,11 +38,13 @@ public struct BoardView: View {
                 .aspectRatio(0.78, contentMode: .fit)
                 .frame(maxHeight: 600)
 
-                ActionBar(viewModel: viewModel) {
-                    selectedSource = nil
+                if showsActionBar {
+                    ActionBar(viewModel: viewModel) {
+                        selectedSource = nil
+                    }
                 }
 
-                if let lastError = viewModel.lastError {
+                if showsActionBar, let lastError = viewModel.lastError {
                     Text(lastError)
                         .font(.footnote)
                         .foregroundStyle(LinenBrass.cream)
@@ -56,6 +67,8 @@ public struct BoardView: View {
     }
 
     private func handlePointTap(_ pointID: PointID) {
+        guard !isReadOnly else { return }
+
         let source: MoveSource = .point(pointID)
         let destination: MoveDestination = .point(pointID)
 
@@ -75,6 +88,8 @@ public struct BoardView: View {
     }
 
     private func handleBarTap() {
+        guard !isReadOnly else { return }
+
         let source: MoveSource = .bar
         if selectedSource == source {
             selectedSource = nil
@@ -84,10 +99,183 @@ public struct BoardView: View {
     }
 
     private func handleBearOffTap() {
+        guard !isReadOnly else { return }
         guard let selectedSource else { return }
         if viewModel.applyMove(from: selectedSource, to: .off) {
             self.selectedSource = nil
         }
+    }
+}
+
+public struct OpponentTurnView: View {
+    public let viewModel: MatchViewModel
+
+    public init(viewModel: MatchViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        BoardView(viewModel: viewModel, isReadOnly: true, showsActionBar: false)
+            .overlay(alignment: .bottom) {
+                opponentStatus
+                    .padding(.horizontal, 18)
+                    .padding(.bottom, 14)
+            }
+    }
+
+    private var opponentStatus: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(LinenBrass.brass)
+                .frame(width: 9, height: 9)
+
+            Text(statusText)
+                .font(LinenBrass.uiFont(size: 15, weight: .semibold))
+                .foregroundStyle(LinenBrass.cream.opacity(0.82))
+                .lineLimit(1)
+                .minimumScaleFactor(0.76)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .frame(minHeight: 42)
+        .background(LinenBrass.coffee.opacity(0.94), in: RoundedRectangle(cornerRadius: 7))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(LinenBrass.brass.opacity(0.34), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("opponent-turn-status")
+    }
+
+    private var statusText: String {
+        if let offer = viewModel.currentCubeOffer, offer.offeredBy == viewModel.localPlayer {
+            return "Waiting for \(viewModel.opponentName) to answer the double"
+        }
+
+        switch viewModel.state.game.phase {
+        case .awaitingRoll:
+            return "Waiting for \(viewModel.opponentName) to roll"
+        case .awaitingMove:
+            return "Waiting for \(viewModel.opponentName) to move"
+        case .awaitingResignationResponse:
+            return "Waiting for \(viewModel.opponentName) to answer"
+        default:
+            return "Waiting for \(viewModel.opponentName)"
+        }
+    }
+}
+
+public struct DoubleOfferSheet: View {
+    public let viewModel: MatchViewModel
+
+    public init(viewModel: MatchViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        ZStack {
+            BoardView(viewModel: viewModel, isReadOnly: true, showsActionBar: false)
+
+            LinenBrass.ink.opacity(0.42)
+                .ignoresSafeArea()
+
+            if let offer = viewModel.doubleOfferForLocalPlayer {
+                offerCard(offer)
+                    .padding(.horizontal, 24)
+            }
+        }
+    }
+
+    private func offerCard(_ offer: CubeOffer) -> some View {
+        VStack(spacing: 18) {
+            CubeView(cube: CubeState(value: offer.proposedValue, owner: viewModel.localPlayer.opponent), localPlayer: viewModel.localPlayer)
+                .frame(width: 54, height: 54)
+
+            VStack(spacing: 6) {
+                Text("\(viewModel.opponentName) is offering a double to \(offer.proposedValue)")
+                    .font(LinenBrass.displayFont(size: 24, weight: .bold))
+                    .foregroundStyle(LinenBrass.ink)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(3)
+                    .minimumScaleFactor(0.78)
+                    .accessibilityIdentifier("double-offer-title")
+
+                Text("The board is frozen until you take or drop.")
+                    .font(LinenBrass.uiFont(size: 14, weight: .medium))
+                    .foregroundStyle(LinenBrass.mutedInk)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+            }
+
+            VStack(spacing: 8) {
+                consequenceRow(
+                    title: "Take",
+                    detail: "Play on with the cube at \(offer.proposedValue)."
+                )
+                consequenceRow(
+                    title: "Drop",
+                    detail: "\(viewModel.opponentName) scores \(pointsText(offer.previousCubeValue))."
+                )
+            }
+
+            HStack(spacing: 12) {
+                Button {
+                    viewModel.dropDoubleIfAllowed()
+                } label: {
+                    Text("Drop")
+                        .font(LinenBrass.uiFont(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity, minHeight: 48)
+                }
+                .buttonStyle(LinenButtonStyle(kind: .secondary))
+                .accessibilityIdentifier("action-drop-double")
+
+                Button {
+                    viewModel.takeDoubleIfAllowed()
+                } label: {
+                    Text("Take")
+                        .font(LinenBrass.uiFont(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity, minHeight: 48)
+                }
+                .buttonStyle(LinenButtonStyle(kind: .primary))
+                .accessibilityIdentifier("action-take-double")
+            }
+        }
+        .padding(22)
+        .frame(maxWidth: 360)
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(LinenBrass.cream)
+                .shadow(color: .black.opacity(0.28), radius: 14, y: 7)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(LinenBrass.brass.opacity(0.72), lineWidth: 1)
+        )
+    }
+
+    private func consequenceRow(title: String, detail: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(title)
+                .font(LinenBrass.uiFont(size: 14, weight: .bold))
+                .foregroundStyle(LinenBrass.ink)
+                .frame(width: 44, alignment: .leading)
+
+            Text(detail)
+                .font(LinenBrass.uiFont(size: 14, weight: .medium))
+                .foregroundStyle(LinenBrass.mutedInk)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 9)
+        .background(LinenBrass.linen, in: RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func pointsText(_ value: Int) -> String {
+        value == 1 ? "1 point" : "\(value) points"
     }
 }
 
@@ -215,6 +403,7 @@ private struct PipStrip: View {
 
 private struct BoardSurface: View {
     let viewModel: MatchViewModel
+    let isReadOnly: Bool
     let selectedSource: MoveSource?
     let onPointTap: (PointID) -> Void
     let onBarTap: () -> Void
@@ -225,8 +414,8 @@ private struct BoardSurface: View {
             let trayHeight = max(68, geometry.size.height * 0.18)
             let halfHeight = (geometry.size.height - trayHeight) / 2
             let barWidth = max(38, geometry.size.width * 0.08)
-            let legalSources = Set(viewModel.legalMoves.map(\.source))
-            let legalDestinations = selectedSource.map { source in
+            let legalSources = isReadOnly ? [] : Set(viewModel.legalMoves.map(\.source))
+            let legalDestinations: Set<MoveDestination> = isReadOnly ? [] : selectedSource.map { source in
                 Set(viewModel.legalMoves.lazy.filter { $0.source == source }.map(\.destination))
             } ?? []
 
@@ -275,6 +464,7 @@ private struct BoardSurface: View {
             .shadow(color: .black.opacity(0.24), radius: 6, y: 3)
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("board")
+            .allowsHitTesting(!isReadOnly)
         }
     }
 

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -61,6 +61,24 @@ public final class MatchViewModel {
         activePlayer == localPlayer
     }
 
+    public var isOpponentTurn: Bool {
+        activePlayer == localPlayer.opponent
+    }
+
+    public var currentCubeOffer: CubeOffer? {
+        if case .awaitingCubeResponse(let offer) = state.game.phase {
+            return offer
+        }
+        return nil
+    }
+
+    public var doubleOfferForLocalPlayer: CubeOffer? {
+        guard let offer = currentCubeOffer, offer.offeredBy.opponent == localPlayer else {
+            return nil
+        }
+        return offer
+    }
+
     public var localScore: Int {
         state.score.score(for: localPlayer)
     }
@@ -121,6 +139,16 @@ public final class MatchViewModel {
     public func offerDoubleIfAllowed() {
         guard containsAction(.offerDouble(localPlayer)) else { return }
         send(.offerDouble(localPlayer))
+    }
+
+    public func takeDoubleIfAllowed() {
+        guard containsAction(.takeDouble(localPlayer)) else { return }
+        send(.takeDouble(localPlayer))
+    }
+
+    public func dropDoubleIfAllowed() {
+        guard containsAction(.dropDouble(localPlayer)) else { return }
+        send(.dropDouble(localPlayer))
     }
 
     public func offerResignationIfAllowed(_ winKind: WinKind) {

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -8,6 +8,12 @@ public struct RootView: View {
     }
 
     public var body: some View {
-        BoardView(viewModel: viewModel)
+        if viewModel.doubleOfferForLocalPlayer != nil {
+            DoubleOfferSheet(viewModel: viewModel)
+        } else if viewModel.isOpponentTurn {
+            OpponentTurnView(viewModel: viewModel)
+        } else {
+            BoardView(viewModel: viewModel)
+        }
     }
 }

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -97,6 +97,57 @@ struct MatchViewModelTests {
 
         #expect(viewModel.lastError == "That move is not legal for the current dice.")
     }
+
+    @Test("opponent double offer is exposed for the local player")
+    @MainActor
+    func opponentDoubleOfferIsExposedForLocalPlayer() {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            config: .tournament(targetScore: 7)
+        )
+
+        advanceToOpponentRoll(viewModel)
+        viewModel.send(.offerDouble(.black))
+
+        let offer = viewModel.doubleOfferForLocalPlayer
+        #expect(offer?.offeredBy == .black)
+        #expect(offer?.proposedValue == 2)
+        #expect(offer?.previousCubeValue == 1)
+        #expect(viewModel.isLocalTurn)
+    }
+
+    @Test("taking an opponent double uses the reducer action")
+    @MainActor
+    func takeOpponentDoubleUsesReducerAction() {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            config: .tournament(targetScore: 7)
+        )
+
+        advanceToOpponentRoll(viewModel)
+        viewModel.send(.offerDouble(.black))
+        viewModel.takeDoubleIfAllowed()
+
+        #expect(viewModel.state.game.cube.value == 2)
+        #expect(viewModel.state.game.cube.owner == .white)
+        guard case .awaitingRoll(.black) = viewModel.state.game.phase else {
+            Issue.record("Expected play to resume at the opponent's roll after taking.")
+            return
+        }
+    }
+}
+
+@MainActor
+private func advanceToOpponentRoll(_ viewModel: MatchViewModel) {
+    viewModel.rollOpeningDice()
+    _ = viewModel.applyMove(
+        from: .point(PointID(rawValue: 24)!),
+        to: .point(PointID(rawValue: 18)!)
+    )
+    _ = viewModel.applyMove(
+        from: .point(PointID(rawValue: 24)!),
+        to: .point(PointID(rawValue: 23)!)
+    )
 }
 
 private final class ScriptedDiceRoller: DiceRolling, @unchecked Sendable {

--- a/SheshBeshUITests/SheshBeshUITests.swift
+++ b/SheshBeshUITests/SheshBeshUITests.swift
@@ -42,7 +42,9 @@ final class SheshBeshUITests: XCTestCase {
 
         element("point-24").tap()
         element("point-23").tap()
-        XCTAssertTrue(app.buttons["action-roll-for-dan"].waitForExistence(timeout: 2))
+        XCTAssertTrue(element("opponent-turn-status").waitForExistence(timeout: 2))
+        XCTAssertTrue(element("opponent-turn-status").label.contains("Waiting for Dan"))
+        XCTAssertFalse(app.buttons["action-roll-for-dan"].exists)
     }
 
     private func element(_ identifier: String) -> XCUIElement {


### PR DESCRIPTION
## Summary
- Splits `RootView` into three modes: interactive `BoardView` for the local player, a read-only `OpponentTurnView` while the opponent is on roll/move/responding, and a `DoubleOfferSheet` that freezes the board while the local player takes or drops a cube offer.
- Adds `isOpponentTurn`, `currentCubeOffer`, `doubleOfferForLocalPlayer`, plus `takeDoubleIfAllowed` / `dropDoubleIfAllowed` to `MatchViewModel`, and threads `isReadOnly` / `showsActionBar` flags through `BoardView` and `BoardSurface` so the same surface renders in passive and active states.
- Adds view-model tests for the opponent-double exposure and take flow, and updates the UI smoke test to expect the opponent-turn status instead of the old "Roll for Dan" button.

## Test plan
- [ ] `./test.sh` (or `swift test` in `Packages/SheshBeshGame` and Xcode tests for the app target)
- [ ] Run the simulator UI test target to confirm the opponent-turn status appears after the local turn ends