### PR TITLE
Fix completed match score persistence

### DIFF
--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -21,7 +21,7 @@ public final class LedgerCoordinator {
 
     public func refresh() async {
         do {
-            let snapshot = try await store.loadAllLedgerData()
+            let snapshot = try await reconciledSnapshot()
             ledgers = snapshot.rivals
                 .map { rival in
                     makeLedger(
@@ -65,24 +65,9 @@ public final class LedgerCoordinator {
     }
 
     public func recordCompletion(of match: ActiveMatch) async throws {
-        guard let completion = match.state.completion else {
-            throw LedgerStoreError.missingMatchCompletion
-        }
-
-        let rivalPlayer = match.userPlayed.opponent
-        let record = MatchRecord(
-            rivalID: match.rivalID,
-            userPlayed: match.userPlayed,
-            winner: completion.winner == match.userPlayed ? .you : .rival,
-            userScore: completion.finalScore.score(for: match.userPlayed),
-            rivalScore: completion.finalScore.score(for: rivalPlayer),
-            targetScore: match.state.config.targetScore,
-            startedAt: match.startedAt,
-            completedAt: Date(),
-            finalSnapshot: match.state
-        )
-
-        try await store.appendMatchRecord(record)
+        let record = try makeRecord(from: match, completedAt: Date())
+        try await store.saveActiveMatch(match)
+        try await appendRecordIfNeeded(record, for: match)
         try await store.clearActiveMatch(rivalID: match.rivalID)
         latestCompletedRecord = record
         await refresh()
@@ -115,5 +100,60 @@ public final class LedgerCoordinator {
             return lhs.rival.displayName.localizedCaseInsensitiveCompare(rhs.rival.displayName) == .orderedAscending
         }
         return lhsDate > rhsDate
+    }
+
+    private func reconciledSnapshot() async throws -> LedgerSnapshot {
+        let snapshot = try await store.loadAllLedgerData()
+        let completedMatches = snapshot.activeMatchesByRival.values.filter { $0.state.completion != nil }
+        guard !completedMatches.isEmpty else { return snapshot }
+
+        for match in completedMatches {
+            let record = try makeRecord(from: match, completedAt: match.lastUpdatedAt)
+            try await appendRecordIfNeeded(record, for: match, existingRecords: snapshot.recordsByRival[match.rivalID, default: []])
+            try await store.clearActiveMatch(rivalID: match.rivalID)
+        }
+
+        return try await store.loadAllLedgerData()
+    }
+
+    private func makeRecord(from match: ActiveMatch, completedAt: Date) throws -> MatchRecord {
+        guard let completion = match.state.completion else {
+            throw LedgerStoreError.missingMatchCompletion
+        }
+
+        let rivalPlayer = match.userPlayed.opponent
+        return MatchRecord(
+            rivalID: match.rivalID,
+            userPlayed: match.userPlayed,
+            winner: completion.winner == match.userPlayed ? .you : .rival,
+            userScore: completion.finalScore.score(for: match.userPlayed),
+            rivalScore: completion.finalScore.score(for: rivalPlayer),
+            targetScore: match.state.config.targetScore,
+            startedAt: match.startedAt,
+            completedAt: completedAt,
+            finalSnapshot: match.state
+        )
+    }
+
+    private func appendRecordIfNeeded(
+        _ record: MatchRecord,
+        for match: ActiveMatch,
+        existingRecords: [MatchRecord]? = nil
+    ) async throws {
+        let records: [MatchRecord]
+        if let existingRecords {
+            records = existingRecords
+        } else {
+            records = try await store.loadMatchRecords(rivalID: match.rivalID)
+        }
+
+        guard !records.contains(where: { existingRecord in
+            existingRecord.startedAt == match.startedAt &&
+            existingRecord.finalSnapshot == match.state
+        }) else {
+            return
+        }
+
+        try await store.appendMatchRecord(record)
     }
 }

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SheshBeshApp
 import SheshBeshGame
 import SheshBeshLedger
@@ -48,6 +49,43 @@ struct LedgerCoordinatorTests {
         #expect(record.finalSnapshot == state)
         #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
         #expect(coordinator.ledger(for: rival.id)?.rivalWins == 1)
+    }
+
+    @Test("refresh recovers completed active match after relaunch")
+    @MainActor
+    func refreshFinalizesCompletedActiveMatch() async throws {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 1_000)
+        let completedAt = Date(timeIntervalSinceReferenceDate: 1_100)
+        let rival = Rival(displayName: "Dan")
+        let state = MatchState(
+            config: MatchConfig(targetScore: 1, usesDoublingCube: false),
+            score: MatchScore(white: 1, black: 0),
+            game: GameState(phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 1))),
+            completion: MatchCompletion(winner: .white, finalScore: MatchScore(white: 1, black: 0))
+        )
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            userPlayed: .white,
+            state: state,
+            startedAt: startedAt,
+            lastUpdatedAt: completedAt
+        )
+        let store = InMemoryLedgerStore(rivals: [rival], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+
+        let records = try await store.loadMatchRecords(rivalID: rival.id)
+        let record = try #require(records.first)
+
+        #expect(records.count == 1)
+        #expect(record.winner == MatchOutcome.you)
+        #expect(record.userScore == 1)
+        #expect(record.rivalScore == 0)
+        #expect(record.completedAt == completedAt)
+        #expect(record.finalSnapshot == state)
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
+        #expect(coordinator.ledger(for: rival.id)?.userWins == 1)
     }
 }
 


### PR DESCRIPTION
This fixes completed simulator matches being lost from the rivalry ledger after quitting and reopening. Ledger refresh now reconciles any completed active match into a durable match record, and completion saves the final active state before clearing it. The record creation logic is shared and avoids duplicate records when reconciling. Added a regression test that simulates relaunching with a completed active match and verifies the rivalry score is restored. Verification: `swift test` passed with 107 tests.