### PR TITLE
Add back button to match screen

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -5,17 +5,20 @@ public struct BoardView: View {
     public let viewModel: MatchViewModel
     private let isReadOnly: Bool
     private let showsActionBar: Bool
+    private let onBackToRivals: (() -> Void)?
 
     @State private var selectedSource: MoveSource?
 
     public init(
         viewModel: MatchViewModel,
         isReadOnly: Bool = false,
-        showsActionBar: Bool = true
+        showsActionBar: Bool = true,
+        onBackToRivals: (() -> Void)? = nil
     ) {
         self.viewModel = viewModel
         self.isReadOnly = isReadOnly
         self.showsActionBar = showsActionBar
+        self.onBackToRivals = onBackToRivals
     }
 
     public var body: some View {
@@ -24,7 +27,7 @@ public struct BoardView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 12) {
-                HeaderCard(viewModel: viewModel)
+                HeaderCard(viewModel: viewModel, onBackToRivals: onBackToRivals)
                 PipStrip(viewModel: viewModel)
 
                 BoardSurface(
@@ -115,13 +118,23 @@ public struct BoardView: View {
 
 public struct OpponentTurnView: View {
     public let viewModel: MatchViewModel
+    private let onBackToRivals: (() -> Void)?
 
-    public init(viewModel: MatchViewModel) {
+    public init(
+        viewModel: MatchViewModel,
+        onBackToRivals: (() -> Void)? = nil
+    ) {
         self.viewModel = viewModel
+        self.onBackToRivals = onBackToRivals
     }
 
     public var body: some View {
-        BoardView(viewModel: viewModel, isReadOnly: true, showsActionBar: false)
+        BoardView(
+            viewModel: viewModel,
+            isReadOnly: true,
+            showsActionBar: false,
+            onBackToRivals: onBackToRivals
+        )
             .overlay(alignment: .bottom) {
                 opponentStatus
                     .padding(.horizontal, 18)
@@ -174,17 +187,28 @@ public struct OpponentTurnView: View {
 
 public struct DoubleOfferSheet: View {
     public let viewModel: MatchViewModel
+    private let onBackToRivals: (() -> Void)?
 
-    public init(viewModel: MatchViewModel) {
+    public init(
+        viewModel: MatchViewModel,
+        onBackToRivals: (() -> Void)? = nil
+    ) {
         self.viewModel = viewModel
+        self.onBackToRivals = onBackToRivals
     }
 
     public var body: some View {
         ZStack {
-            BoardView(viewModel: viewModel, isReadOnly: true, showsActionBar: false)
+            BoardView(
+                viewModel: viewModel,
+                isReadOnly: true,
+                showsActionBar: false,
+                onBackToRivals: onBackToRivals
+            )
 
             LinenBrass.ink.opacity(0.42)
                 .ignoresSafeArea()
+                .allowsHitTesting(false)
 
             if let offer = viewModel.doubleOfferForLocalPlayer {
                 offerCard(offer)
@@ -329,10 +353,24 @@ private struct LinenBackground: View {
 
 private struct HeaderCard: View {
     let viewModel: MatchViewModel
+    let onBackToRivals: (() -> Void)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 7) {
-            HStack(alignment: .lastTextBaseline) {
+            HStack(alignment: .center, spacing: 10) {
+                if let onBackToRivals {
+                    Button(action: onBackToRivals) {
+                        Label("Rivals", systemImage: "chevron.left")
+                            .font(LinenBrass.uiFont(size: 14, weight: .semibold))
+                            .labelStyle(.titleAndIcon)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.78)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(LinenBrass.coffee)
+                    .accessibilityIdentifier("match-back-button")
+                }
+
                 Text("YOU vs \(viewModel.opponentName.uppercased())")
                     .font(LinenBrass.displayFont(size: 28, weight: .bold))
                     .lineLimit(1)

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -32,7 +32,9 @@ public struct RootView: View {
             if let singleMatchViewModel {
                 matchView(for: singleMatchViewModel)
             } else if let activeMatchViewModel {
-                matchView(for: activeMatchViewModel)
+                matchView(for: activeMatchViewModel) {
+                    self.activeMatchViewModel = nil
+                }
                     .sheet(item: $completedRecord) { record in
                         MatchEndSheet(
                             record: record,
@@ -65,13 +67,16 @@ public struct RootView: View {
     }
 
     @ViewBuilder
-    private func matchView(for viewModel: MatchViewModel) -> some View {
+    private func matchView(
+        for viewModel: MatchViewModel,
+        onBackToRivals: (() -> Void)? = nil
+    ) -> some View {
         if viewModel.doubleOfferForLocalPlayer != nil {
-            DoubleOfferSheet(viewModel: viewModel)
+            DoubleOfferSheet(viewModel: viewModel, onBackToRivals: onBackToRivals)
         } else if viewModel.isOpponentTurn {
-            OpponentTurnView(viewModel: viewModel)
+            OpponentTurnView(viewModel: viewModel, onBackToRivals: onBackToRivals)
         } else {
-            BoardView(viewModel: viewModel)
+            BoardView(viewModel: viewModel, onBackToRivals: onBackToRivals)
         }
     }
 


### PR DESCRIPTION
Adds a Rivals back button to active ledger match screens so players can return to the rival list. Wires the back callback through normal board, opponent-turn, and double-offer states while keeping standalone quick matches unchanged. Also keeps the double-offer dimming layer from swallowing the back-button tap. Tested with scripts/test.sh.