### PR TITLE
Add Game Center async multiplayer

### DIFF
--- a/Packages/SheshBeshLedger/Sources/SheshBeshLedger/ActiveMatch.swift
+++ b/Packages/SheshBeshLedger/Sources/SheshBeshLedger/ActiveMatch.swift
@@ -4,6 +4,8 @@ import SheshBeshGame
 public struct ActiveMatch: Identifiable, Codable, Equatable, Sendable {
     public let id: UUID
     public let rivalID: Rival.ID
+    public let gameCenterMatchID: String?
+    public let gameIndex: Int
     public let userPlayed: Player
     public var state: MatchState
     public let startedAt: Date
@@ -12,6 +14,8 @@ public struct ActiveMatch: Identifiable, Codable, Equatable, Sendable {
     public init(
         id: UUID = UUID(),
         rivalID: Rival.ID,
+        gameCenterMatchID: String? = nil,
+        gameIndex: Int = 0,
         userPlayed: Player,
         state: MatchState,
         startedAt: Date = Date(),
@@ -19,6 +23,8 @@ public struct ActiveMatch: Identifiable, Codable, Equatable, Sendable {
     ) {
         self.id = id
         self.rivalID = rivalID
+        self.gameCenterMatchID = gameCenterMatchID
+        self.gameIndex = gameIndex
         self.userPlayed = userPlayed
         self.state = state
         self.startedAt = startedAt

--- a/Packages/SheshBeshLedger/Sources/SheshBeshLedger/MatchRecord.swift
+++ b/Packages/SheshBeshLedger/Sources/SheshBeshLedger/MatchRecord.swift
@@ -4,6 +4,8 @@ import SheshBeshGame
 public struct MatchRecord: Identifiable, Codable, Equatable, Hashable, Sendable {
     public let id: UUID
     public let rivalID: Rival.ID
+    public let gameCenterMatchID: String?
+    public let gameIndex: Int
     public let userPlayed: Player
     public let winner: MatchOutcome
     public let userScore: Int
@@ -16,6 +18,8 @@ public struct MatchRecord: Identifiable, Codable, Equatable, Hashable, Sendable 
     public init(
         id: UUID = UUID(),
         rivalID: Rival.ID,
+        gameCenterMatchID: String? = nil,
+        gameIndex: Int = 0,
         userPlayed: Player,
         winner: MatchOutcome,
         userScore: Int,
@@ -27,6 +31,8 @@ public struct MatchRecord: Identifiable, Codable, Equatable, Hashable, Sendable 
     ) {
         self.id = id
         self.rivalID = rivalID
+        self.gameCenterMatchID = gameCenterMatchID
+        self.gameIndex = gameIndex
         self.userPlayed = userPlayed
         self.winner = winner
         self.userScore = userScore

--- a/Packages/SheshBeshLedger/Sources/SheshBeshLedger/Rival.swift
+++ b/Packages/SheshBeshLedger/Sources/SheshBeshLedger/Rival.swift
@@ -3,15 +3,21 @@ import Foundation
 public struct Rival: Identifiable, Codable, Equatable, Hashable, Sendable {
     public let id: UUID
     public var displayName: String
+    public var gameCenterPlayerID: String?
+    public var gameCenterDisplayName: String?
     public let createdAt: Date
 
     public init(
         id: UUID = UUID(),
         displayName: String,
+        gameCenterPlayerID: String? = nil,
+        gameCenterDisplayName: String? = nil,
         createdAt: Date = Date()
     ) {
         self.id = id
         self.displayName = displayName
+        self.gameCenterPlayerID = gameCenterPlayerID
+        self.gameCenterDisplayName = gameCenterDisplayName
         self.createdAt = createdAt
     }
 }

--- a/SheshBesh.xcodeproj/project.pbxproj
+++ b/SheshBesh.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		AF3000000000000000000013 /* InMemoryLedgerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3000000000000000000014 /* InMemoryLedgerStore.swift */; };
 		AF3000000000000000000015 /* JSONLedgerStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3000000000000000000016 /* JSONLedgerStore.swift */; };
 		AF3000000000000000000017 /* LedgerAggregation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3000000000000000000018 /* LedgerAggregation.swift */; };
+		AF4000000000000000000001 /* GameCenterEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4000000000000000000002 /* GameCenterEnvelope.swift */; };
+		AF4000000000000000000003 /* GameCenterSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4000000000000000000004 /* GameCenterSupport.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +85,9 @@
 		AF3000000000000000000014 /* InMemoryLedgerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryLedgerStore.swift; sourceTree = "<group>"; };
 		AF3000000000000000000016 /* JSONLedgerStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONLedgerStore.swift; sourceTree = "<group>"; };
 		AF3000000000000000000018 /* LedgerAggregation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LedgerAggregation.swift; sourceTree = "<group>"; };
+		AF4000000000000000000002 /* GameCenterEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCenterEnvelope.swift; sourceTree = "<group>"; };
+		AF4000000000000000000004 /* GameCenterSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCenterSupport.swift; sourceTree = "<group>"; };
+		AF4000000000000000000005 /* SheshBesh.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SheshBesh.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +132,7 @@
 				AF1000000000000000000023 /* App */,
 				AF1000000000000000000024 /* Shared */,
 				AF1000000000000000000039 /* Assets.xcassets */,
+				AF4000000000000000000005 /* SheshBesh.entitlements */,
 			);
 			path = SheshBesh;
 			sourceTree = "<group>";
@@ -163,6 +169,8 @@
 			children = (
 				AF1000000000000000000037 /* AppLaunchConfiguration.swift */,
 				AF1000000000000000000008 /* BoardView.swift */,
+				AF4000000000000000000002 /* GameCenterEnvelope.swift */,
+				AF4000000000000000000004 /* GameCenterSupport.swift */,
 				AF3000000000000000000004 /* HomeView.swift */,
 				AF3000000000000000000002 /* LedgerCoordinator.swift */,
 				AF1000000000000000000006 /* MatchViewModel.swift */,
@@ -365,6 +373,8 @@
 				AF1000000000000000000001 /* SheshBeshMain.swift in Sources */,
 				AF1000000000000000000036 /* AppLaunchConfiguration.swift in Sources */,
 				AF1000000000000000000007 /* BoardView.swift in Sources */,
+				AF4000000000000000000001 /* GameCenterEnvelope.swift in Sources */,
+				AF4000000000000000000003 /* GameCenterSupport.swift in Sources */,
 				AF3000000000000000000003 /* HomeView.swift in Sources */,
 				AF3000000000000000000001 /* LedgerCoordinator.swift in Sources */,
 				AF1000000000000000000005 /* MatchViewModel.swift in Sources */,
@@ -507,6 +517,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = SheshBesh/SheshBesh.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8DDY9Z9MX6;
@@ -537,6 +548,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = SheshBesh/SheshBesh.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8DDY9Z9MX6;

--- a/SheshBesh/Shared/GameCenterEnvelope.swift
+++ b/SheshBesh/Shared/GameCenterEnvelope.swift
@@ -1,0 +1,173 @@
+import CryptoKit
+import Foundation
+import SheshBeshGame
+
+public struct GameCenterPlayerMapping: Codable, Equatable, Hashable, Sendable {
+    public var whitePlayerID: String
+    public var blackPlayerID: String
+    public var whiteDisplayName: String
+    public var blackDisplayName: String
+
+    public init(
+        whitePlayerID: String,
+        blackPlayerID: String,
+        whiteDisplayName: String,
+        blackDisplayName: String
+    ) {
+        self.whitePlayerID = whitePlayerID
+        self.blackPlayerID = blackPlayerID
+        self.whiteDisplayName = whiteDisplayName
+        self.blackDisplayName = blackDisplayName
+    }
+
+    public func player(forGameCenterID playerID: String) -> Player? {
+        if playerID == whitePlayerID { return .white }
+        if playerID == blackPlayerID { return .black }
+        return nil
+    }
+
+    public func gameCenterID(for player: Player) -> String {
+        switch player {
+        case .white:
+            whitePlayerID
+        case .black:
+            blackPlayerID
+        }
+    }
+
+    public func displayName(for player: Player) -> String {
+        switch player {
+        case .white:
+            whiteDisplayName
+        case .black:
+            blackDisplayName
+        }
+    }
+}
+
+public struct GameCenterMatchEnvelope: Codable, Equatable, Hashable, Sendable {
+    public static let currentSchemaVersion = 1
+    public static let minimumSupportedSchemaVersion = 1
+
+    public var schemaVersion: Int
+    public var minimumSupportedSchemaVersion: Int
+    public var revision: Int
+    public var turnCounter: Int
+    public var gameIndex: Int
+    public var gameCenterMatchID: String
+    public var playerMapping: GameCenterPlayerMapping
+    public var config: MatchConfig
+    public var state: MatchState
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        minimumSupportedSchemaVersion: Int = Self.minimumSupportedSchemaVersion,
+        revision: Int = 0,
+        turnCounter: Int = 0,
+        gameIndex: Int = 0,
+        gameCenterMatchID: String,
+        playerMapping: GameCenterPlayerMapping,
+        config: MatchConfig,
+        state: MatchState
+    ) {
+        self.schemaVersion = schemaVersion
+        self.minimumSupportedSchemaVersion = minimumSupportedSchemaVersion
+        self.revision = revision
+        self.turnCounter = turnCounter
+        self.gameIndex = gameIndex
+        self.gameCenterMatchID = gameCenterMatchID
+        self.playerMapping = playerMapping
+        self.config = config
+        self.state = state
+    }
+
+    public func validateSupported() throws {
+        guard schemaVersion <= Self.currentSchemaVersion else {
+            throw GameCenterEnvelopeError.futureSchemaVersion(schemaVersion)
+        }
+        guard minimumSupportedSchemaVersion <= Self.currentSchemaVersion else {
+            throw GameCenterEnvelopeError.futureMinimumSupportedSchemaVersion(minimumSupportedSchemaVersion)
+        }
+    }
+
+    public func encoded() throws -> Data {
+        try JSONEncoder.gameCenterEnvelope.encode(self)
+    }
+
+    public static func decoded(from data: Data) throws -> GameCenterMatchEnvelope {
+        let envelope = try JSONDecoder.gameCenterEnvelope.decode(GameCenterMatchEnvelope.self, from: data)
+        try envelope.validateSupported()
+        return envelope
+    }
+}
+
+public enum GameCenterEnvelopeError: Error, Equatable, LocalizedError, Sendable {
+    case emptyMatchData
+    case futureSchemaVersion(Int)
+    case futureMinimumSupportedSchemaVersion(Int)
+    case corruptMatchData
+    case matchDataTooLarge(Int, maximum: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .emptyMatchData:
+            "This Game Center match does not have game data yet."
+        case .futureSchemaVersion:
+            "Update Shesh Besh to continue this match."
+        case .futureMinimumSupportedSchemaVersion:
+            "Update Shesh Besh to continue this match."
+        case .corruptMatchData:
+            "This match data could not be read. Try reloading the match."
+        case .matchDataTooLarge(let size, let maximum):
+            "The match data is \(size) bytes, above Game Center's \(maximum)-byte limit."
+        }
+    }
+}
+
+public final class GameCenterDiceRoller: DiceRolling, @unchecked Sendable {
+    private var state: UInt64
+
+    public init(matchID: String, turnCounter: Int, revision: Int = 0) {
+        self.state = Self.seed(matchID: matchID, turnCounter: turnCounter, revision: revision)
+    }
+
+    public func rollDie() -> Int {
+        let value = next()
+        return Int(value % 6) + 1
+    }
+
+    private func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var value = state
+        value = (value ^ (value >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        value = (value ^ (value >> 27)) &* 0x94D0_49BB_1331_11EB
+        return value ^ (value >> 31)
+    }
+
+    public static func seed(matchID: String, turnCounter: Int, revision: Int = 0) -> UInt64 {
+        stableHash(matchID)
+            ^ (UInt64(bitPattern: Int64(turnCounter)) &* 0xD6E8_FEB8_6659_FD93)
+            ^ (UInt64(bitPattern: Int64(revision)) &* 0xA5A3_58EF_1BBC_3F43)
+    }
+
+    public static func stableHash(_ string: String) -> UInt64 {
+        let digest = SHA256.hash(data: Data(string.utf8))
+        return digest.prefix(8).reduce(UInt64(0)) { partial, byte in
+            (partial << 8) | UInt64(byte)
+        }
+    }
+}
+
+private extension JSONEncoder {
+    static var gameCenterEnvelope: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}
+
+private extension JSONDecoder {
+    static var gameCenterEnvelope: JSONDecoder {
+        JSONDecoder()
+    }
+}

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -1,0 +1,851 @@
+#if canImport(GameKit) && canImport(UIKit)
+@preconcurrency import GameKit
+import Observation
+import SheshBeshGame
+import SwiftUI
+@preconcurrency import UIKit
+
+#if canImport(SheshBeshLedger)
+import SheshBeshLedger
+#endif
+
+public enum GameCenterAuthState: Equatable, Sendable {
+    case notStarted
+    case authenticating
+    case authenticated(displayName: String)
+    case unauthenticated(String)
+
+    public var isAuthenticated: Bool {
+        if case .authenticated = self { return true }
+        return false
+    }
+}
+
+@MainActor
+@Observable
+public final class GameCenterSession: NSObject, GKLocalPlayerListener {
+    public private(set) var authState: GameCenterAuthState = .notStarted
+    public private(set) var localPlayerID: String?
+    public private(set) var localDisplayName: String?
+    public var authenticationViewController: UIViewController?
+    public var lastErrorMessage: String?
+
+    @ObservationIgnored public var onTurnEvent: (@MainActor (GKTurnBasedMatch, Bool) -> Void)?
+    @ObservationIgnored public var onMatchEnded: (@MainActor (GKTurnBasedMatch) -> Void)?
+
+    public func authenticate() {
+        authState = .authenticating
+        GKLocalPlayer.local.authenticateHandler = { [weak self] viewController, error in
+            Task { @MainActor in
+                guard let self else { return }
+
+                if let viewController {
+                    self.authenticationViewController = viewController
+                    self.authState = .authenticating
+                    return
+                }
+
+                if GKLocalPlayer.local.isAuthenticated {
+                    self.authenticationViewController = nil
+                    self.localPlayerID = GKLocalPlayer.local.gamePlayerID
+                    self.localDisplayName = GKLocalPlayer.local.displayName
+                    self.lastErrorMessage = nil
+                    self.authState = .authenticated(displayName: GKLocalPlayer.local.displayName)
+                    GKLocalPlayer.local.register(self)
+                } else {
+                    let message = error?.localizedDescription ?? "Sign in to Game Center to play with friends."
+                    self.authenticationViewController = nil
+                    self.localPlayerID = nil
+                    self.localDisplayName = nil
+                    self.lastErrorMessage = message
+                    self.authState = .unauthenticated(message)
+                }
+            }
+        }
+    }
+
+    public func loadMatches() async throws -> [GameCenterTurnBasedMatchBox] {
+        try await withCheckedThrowingContinuation { continuation in
+            GKTurnBasedMatch.loadMatches { matches, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: (matches ?? []).map(GameCenterTurnBasedMatchBox.init(match:)))
+                }
+            }
+        }
+    }
+
+    nonisolated public func player(
+        _ player: GKPlayer,
+        receivedTurnEventFor match: GKTurnBasedMatch,
+        didBecomeActive: Bool
+    ) {
+        let matchBox = GameCenterTurnBasedMatchBox(match: match)
+        DispatchQueue.main.async { [weak self] in
+            self?.onTurnEvent?(matchBox.match, didBecomeActive)
+        }
+    }
+
+    nonisolated public func player(_ player: GKPlayer, matchEnded match: GKTurnBasedMatch) {
+        let matchBox = GameCenterTurnBasedMatchBox(match: match)
+        DispatchQueue.main.async { [weak self] in
+            self?.onMatchEnded?(matchBox.match)
+        }
+    }
+}
+
+public final class GameCenterTurnBasedMatchBox: @unchecked Sendable, Identifiable {
+    public let id: String
+    public let match: GKTurnBasedMatch
+
+    public init(match: GKTurnBasedMatch) {
+        self.id = match.matchID
+        self.match = match
+    }
+}
+
+public struct GameCenterAuthenticationSheet: UIViewControllerRepresentable {
+    public let viewController: UIViewController
+
+    public init(viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    public func makeUIViewController(context: Context) -> UIViewController {
+        viewController
+    }
+
+    public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}
+
+public struct GameCenterLoadedMatch {
+    public var match: GKTurnBasedMatch
+    public var envelope: GameCenterMatchEnvelope
+    public var activeMatch: ActiveMatch
+    public var rival: Rival
+    public var localPlayerID: String
+
+    public var localPlayer: Player {
+        envelope.playerMapping.player(forGameCenterID: localPlayerID) ?? .white
+    }
+
+    public var opponentPlayer: Player {
+        localPlayer.opponent
+    }
+
+    public var opponentDisplayName: String {
+        envelope.playerMapping.displayName(for: opponentPlayer)
+    }
+
+    public var isLocalTurn: Bool {
+        match.currentParticipant?.player?.gamePlayerID == localPlayerID
+    }
+}
+
+@MainActor
+public final class GameCenterMatchCoordinator {
+    private let ledgerCoordinator: LedgerCoordinator
+
+    public init(ledgerCoordinator: LedgerCoordinator) {
+        self.ledgerCoordinator = ledgerCoordinator
+    }
+
+    public func load(match: GKTurnBasedMatch, targetScore: Int = 7) async throws -> GameCenterLoadedMatch {
+        let localPlayerID = GKLocalPlayer.local.gamePlayerID
+        let data = try await match.loadGameData()
+        let envelope: GameCenterMatchEnvelope
+
+        if let data, !data.isEmpty {
+            do {
+                envelope = try Self.resolvingParticipants(
+                    in: GameCenterMatchEnvelope.decoded(from: data),
+                    match: match
+                )
+            } catch let error as GameCenterEnvelopeError {
+                throw error
+            } catch {
+                throw GameCenterEnvelopeError.corruptMatchData
+            }
+        } else {
+            envelope = Self.newEnvelope(
+                for: match,
+                localPlayerID: localPlayerID,
+                targetScore: targetScore
+            )
+            if match.currentParticipant?.player?.gamePlayerID == localPlayerID {
+                try await save(envelope: envelope, to: match)
+            }
+        }
+
+        return try await reconcileLedger(for: match, envelope: envelope, localPlayerID: localPlayerID)
+    }
+
+    public func commit(state: MatchState, for loaded: GameCenterLoadedMatch) async throws -> GameCenterLoadedMatch {
+        guard loaded.match.currentParticipant?.player?.gamePlayerID == loaded.localPlayerID else {
+            throw GameCenterCoordinatorError.notLocalPlayersTurn
+        }
+
+        var envelope = loaded.envelope
+        envelope.revision += 1
+        envelope.gameIndex = max(0, state.gameNumber - 1)
+        envelope.state = state
+        envelope.config = state.config
+
+        let data = try validatedData(for: envelope, maximumSize: loaded.match.matchDataMaximumSize)
+
+        if state.completion != nil {
+            try await endMatch(loaded.match, envelope: envelope, data: data)
+        } else if let activePlayer = activePlayer(in: state),
+                  activePlayer != loaded.localPlayer {
+            envelope.turnCounter += 1
+            let turnData = try validatedData(for: envelope, maximumSize: loaded.match.matchDataMaximumSize)
+            let nextParticipant = try participant(for: activePlayer, in: loaded.match, envelope: envelope)
+            try await loaded.match.endTurn(to: nextParticipant, data: turnData)
+        } else {
+            try await loaded.match.saveCurrentTurnData(data)
+        }
+
+        let updated = try await reconcileLedger(
+            for: loaded.match,
+            envelope: envelope,
+            localPlayerID: loaded.localPlayerID
+        )
+
+        if state.completion != nil {
+            try await ledgerCoordinator.recordCompletion(of: updated.activeMatch)
+        }
+
+        return updated
+    }
+
+    public func sendReminder(for loaded: GameCenterLoadedMatch) async throws {
+        let nextParticipant = try participant(for: loaded.opponentPlayer, in: loaded.match, envelope: loaded.envelope)
+        try await loaded.match.sendGameCenterReminder(to: nextParticipant)
+    }
+
+    private func reconcileLedger(
+        for match: GKTurnBasedMatch,
+        envelope: GameCenterMatchEnvelope,
+        localPlayerID: String
+    ) async throws -> GameCenterLoadedMatch {
+        await ledgerCoordinator.refresh()
+
+        let localPlayer = envelope.playerMapping.player(forGameCenterID: localPlayerID) ?? .white
+        let opponent = localPlayer.opponent
+        let opponentID = envelope.playerMapping.gameCenterID(for: opponent)
+        let opponentName = envelope.playerMapping.displayName(for: opponent)
+
+        let rival = ledgerCoordinator.rival(matchingGameCenterPlayerID: opponentID)
+            ?? Rival(
+                displayName: opponentName,
+                gameCenterPlayerID: opponentID,
+                gameCenterDisplayName: opponentName
+            )
+        let existingActive = ledgerCoordinator.activeMatch(gameCenterMatchID: match.matchID)
+        let activeMatch = ActiveMatch(
+            id: existingActive?.id ?? UUID(),
+            rivalID: rival.id,
+            gameCenterMatchID: match.matchID,
+            gameIndex: envelope.gameIndex,
+            userPlayed: localPlayer,
+            state: envelope.state,
+            startedAt: existingActive?.startedAt ?? match.creationDate,
+            lastUpdatedAt: Date()
+        )
+
+        try await ledgerCoordinator.saveGameCenterMatch(activeMatch, rival: rival)
+
+        return GameCenterLoadedMatch(
+            match: match,
+            envelope: envelope,
+            activeMatch: activeMatch,
+            rival: rival,
+            localPlayerID: localPlayerID
+        )
+    }
+
+    private func save(envelope: GameCenterMatchEnvelope, to match: GKTurnBasedMatch) async throws {
+        let data = try validatedData(for: envelope, maximumSize: match.matchDataMaximumSize)
+        try await match.saveCurrentTurnData(data)
+    }
+
+    private func endMatch(
+        _ match: GKTurnBasedMatch,
+        envelope: GameCenterMatchEnvelope,
+        data: Data
+    ) async throws {
+        guard let completion = envelope.state.completion else { return }
+        let winnerID = envelope.playerMapping.gameCenterID(for: completion.winner)
+
+        for participant in match.participants {
+            participant.matchOutcome = participant.player?.gamePlayerID == winnerID ? .won : .lost
+        }
+
+        try await match.endMatch(data: data)
+    }
+
+    private func validatedData(for envelope: GameCenterMatchEnvelope, maximumSize: Int) throws -> Data {
+        let data = try envelope.encoded()
+        guard data.count <= maximumSize else {
+            throw GameCenterEnvelopeError.matchDataTooLarge(data.count, maximum: maximumSize)
+        }
+        return data
+    }
+
+    private func activePlayer(in state: MatchState) -> Player? {
+        switch state.game.phase {
+        case .awaitingOpeningRoll:
+            nil
+        case .awaitingRoll(let player):
+            player
+        case .awaitingMove(let turn):
+            turn.player
+        case .awaitingCubeResponse(let offer):
+            offer.offeredBy.opponent
+        case .awaitingResignationResponse(let offer):
+            offer.offeredBy.opponent
+        case .gameOver:
+            nil
+        }
+    }
+
+    private func participant(
+        for player: Player,
+        in match: GKTurnBasedMatch,
+        envelope: GameCenterMatchEnvelope
+    ) throws -> GKTurnBasedParticipant {
+        let playerID = envelope.playerMapping.gameCenterID(for: player)
+        guard let participant = match.participants.first(where: { $0.player?.gamePlayerID == playerID }) else {
+            throw GameCenterCoordinatorError.missingParticipant
+        }
+        return participant
+    }
+
+    private static func newEnvelope(
+        for match: GKTurnBasedMatch,
+        localPlayerID: String,
+        targetScore: Int
+    ) -> GameCenterMatchEnvelope {
+        let opponent = match.participants.first { participant in
+            guard let playerID = participant.player?.gamePlayerID else { return false }
+            return playerID != localPlayerID
+        }
+        let opponentID = opponent?.player?.gamePlayerID ?? "pending-\(match.matchID)"
+        let opponentName = opponent?.player?.displayName ?? "Opponent"
+        let config = MatchConfig.tournament(targetScore: targetScore)
+
+        return GameCenterMatchEnvelope(
+            gameCenterMatchID: match.matchID,
+            playerMapping: GameCenterPlayerMapping(
+                whitePlayerID: localPlayerID,
+                blackPlayerID: opponentID,
+                whiteDisplayName: GKLocalPlayer.local.displayName,
+                blackDisplayName: opponentName
+            ),
+            config: config,
+            state: MatchEngine.newMatch(config: config)
+        )
+    }
+
+    private static func resolvingParticipants(
+        in envelope: GameCenterMatchEnvelope,
+        match: GKTurnBasedMatch
+    ) -> GameCenterMatchEnvelope {
+        var envelope = envelope
+        let participants = match.participants.compactMap(\.player)
+
+        if envelope.playerMapping.whitePlayerID.hasPrefix("pending-"),
+           let white = participants.first(where: { $0.gamePlayerID != envelope.playerMapping.blackPlayerID }) {
+            envelope.playerMapping.whitePlayerID = white.gamePlayerID
+            envelope.playerMapping.whiteDisplayName = white.displayName
+        }
+
+        if envelope.playerMapping.blackPlayerID.hasPrefix("pending-"),
+           let black = participants.first(where: { $0.gamePlayerID != envelope.playerMapping.whitePlayerID }) {
+            envelope.playerMapping.blackPlayerID = black.gamePlayerID
+            envelope.playerMapping.blackDisplayName = black.displayName
+        }
+
+        return envelope
+    }
+}
+
+public enum GameCenterCoordinatorError: Error, LocalizedError, Sendable {
+    case missingParticipant
+    case notLocalPlayersTurn
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingParticipant:
+            "Game Center has not resolved the opponent for this match yet."
+        case .notLocalPlayersTurn:
+            "This Game Center match is not currently your turn."
+        }
+    }
+}
+
+public struct GameCenterMatchmakerSheet: UIViewControllerRepresentable {
+    public let targetScore: Int
+    public let onMatchFound: @MainActor (GKTurnBasedMatch, Int) -> Void
+    public let onCancel: @MainActor () -> Void
+    public let onError: @MainActor (Error) -> Void
+
+    public init(
+        targetScore: Int,
+        onMatchFound: @escaping @MainActor (GKTurnBasedMatch, Int) -> Void,
+        onCancel: @escaping @MainActor () -> Void,
+        onError: @escaping @MainActor (Error) -> Void
+    ) {
+        self.targetScore = targetScore
+        self.onMatchFound = onMatchFound
+        self.onCancel = onCancel
+        self.onError = onError
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    public func makeUIViewController(context: Context) -> GKTurnBasedMatchmakerViewController {
+        let request = GKMatchRequest()
+        request.minPlayers = 2
+        request.maxPlayers = 2
+        request.defaultNumberOfPlayers = 2
+        request.inviteMessage = "Play a \(targetScore)-point Shesh Besh match."
+
+        let controller = GKTurnBasedMatchmakerViewController(matchRequest: request)
+        controller.turnBasedMatchmakerDelegate = context.coordinator
+        controller.showExistingMatches = true
+        return controller
+    }
+
+    public func updateUIViewController(_ uiViewController: GKTurnBasedMatchmakerViewController, context: Context) {}
+
+    public final class Coordinator: NSObject, @MainActor GKTurnBasedMatchmakerViewControllerDelegate {
+        private let parent: GameCenterMatchmakerSheet
+
+        init(parent: GameCenterMatchmakerSheet) {
+            self.parent = parent
+        }
+
+        @MainActor
+        public func turnBasedMatchmakerViewControllerWasCancelled(_ viewController: GKTurnBasedMatchmakerViewController) {
+            viewController.dismiss(animated: true)
+            parent.onCancel()
+        }
+
+        @MainActor
+        public func turnBasedMatchmakerViewController(
+            _ viewController: GKTurnBasedMatchmakerViewController,
+            didFailWithError error: any Error
+        ) {
+            viewController.dismiss(animated: true)
+            parent.onError(error)
+        }
+
+        @MainActor
+        public func turnBasedMatchmakerViewController(
+            _ viewController: GKTurnBasedMatchmakerViewController,
+            didFind match: GKTurnBasedMatch
+        ) {
+            viewController.dismiss(animated: true)
+            parent.onMatchFound(match, parent.targetScore)
+        }
+    }
+}
+
+public struct GameCenterHomeView: View {
+    public let session: GameCenterSession
+    public let ledgerCoordinator: LedgerCoordinator
+    public let matchCoordinator: GameCenterMatchCoordinator
+    public let onOpenMatch: (GameCenterLoadedMatch) -> Void
+
+    @State private var matches: [GameCenterLoadedMatch] = []
+    @State private var isLoadingMatches = false
+    @State private var isShowingMatchmaker = false
+    @State private var isSelectingTargetScore = false
+    @State private var selectedTargetScore = 7
+    @State private var localError: String?
+
+    public init(
+        session: GameCenterSession,
+        ledgerCoordinator: LedgerCoordinator,
+        matchCoordinator: GameCenterMatchCoordinator,
+        onOpenMatch: @escaping (GameCenterLoadedMatch) -> Void
+    ) {
+        self.session = session
+        self.ledgerCoordinator = ledgerCoordinator
+        self.matchCoordinator = matchCoordinator
+        self.onOpenMatch = onOpenMatch
+    }
+
+    public var body: some View {
+        ZStack {
+            LedgerBackground()
+                .ignoresSafeArea()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    authPanel
+
+                    if session.authState.isAuthenticated {
+                        matchControls
+                        matchList
+                        ledgerSummary
+                    }
+                }
+                .padding(.horizontal, 18)
+                .padding(.top, 18)
+                .padding(.bottom, 28)
+            }
+        }
+        .task {
+            if session.authState == .notStarted {
+                session.authenticate()
+            }
+            await refresh()
+        }
+        .onChange(of: session.authState) {
+            Task { await refresh() }
+        }
+        .sheet(item: authenticationBinding) { controller in
+            GameCenterAuthenticationSheet(viewController: controller.viewController)
+        }
+        .sheet(isPresented: $isShowingMatchmaker) {
+            GameCenterMatchmakerSheet(
+                targetScore: selectedTargetScore,
+                onMatchFound: { match, targetScore in
+                    Task { await loadAndOpen(match: match, targetScore: targetScore) }
+                },
+                onCancel: {},
+                onError: { error in localError = error.localizedDescription }
+            )
+        }
+        .confirmationDialog("Match length", isPresented: $isSelectingTargetScore) {
+            Button("7 points") {
+                selectedTargetScore = 7
+                isShowingMatchmaker = true
+            }
+            Button("11 points") {
+                selectedTargetScore = 11
+                isShowingMatchmaker = true
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .alert(
+            "Game Center Error",
+            isPresented: Binding(
+                get: { localError != nil || session.lastErrorMessage != nil || ledgerCoordinator.lastErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        localError = nil
+                        session.lastErrorMessage = nil
+                        ledgerCoordinator.clearError()
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(localError ?? session.lastErrorMessage ?? ledgerCoordinator.lastErrorMessage ?? "")
+        }
+    }
+
+    private var authenticationBinding: Binding<AuthenticationController?> {
+        Binding {
+            session.authenticationViewController.map(AuthenticationController.init(viewController:))
+        } set: { value in
+            if value == nil {
+                session.authenticationViewController = nil
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Rivalries")
+                .font(LedgerTheme.displayFont(size: 34, weight: .bold))
+                .foregroundStyle(LedgerTheme.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+
+            Text("Game Center async matches")
+                .font(LedgerTheme.uiFont(size: 14, weight: .semibold))
+                .foregroundStyle(LedgerTheme.mutedInk)
+                .textCase(.uppercase)
+                .tracking(0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var authPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(authTitle)
+                .font(LedgerTheme.displayFont(size: 24, weight: .bold))
+                .foregroundStyle(LedgerTheme.ink)
+                .lineLimit(2)
+                .minimumScaleFactor(0.72)
+
+            if !session.authState.isAuthenticated {
+                Button {
+                    session.authenticate()
+                } label: {
+                    Label("Sign in", systemImage: "person.crop.circle.badge.checkmark")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(LedgerTheme.rust)
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(LedgerTheme.brass.opacity(0.72), lineWidth: 1)
+        )
+    }
+
+    private var authTitle: String {
+        switch session.authState {
+        case .notStarted, .authenticating:
+            "Connecting to Game Center"
+        case .authenticated(let displayName):
+            "Signed in as \(displayName)"
+        case .unauthenticated:
+            "Sign in to Game Center"
+        }
+    }
+
+    private var matchControls: some View {
+        HStack(spacing: 10) {
+            Button {
+                isSelectingTargetScore = true
+            } label: {
+                Label("New match", systemImage: "plus")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(LedgerTheme.rust)
+
+            Button {
+                Task { await refresh() }
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+                    .labelStyle(.iconOnly)
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.bordered)
+            .tint(LedgerTheme.coffee)
+            .disabled(isLoadingMatches)
+        }
+    }
+
+    private var matchList: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Matches")
+                .font(LedgerTheme.uiFont(size: 13, weight: .bold))
+                .foregroundStyle(LedgerTheme.mutedInk)
+                .textCase(.uppercase)
+
+            if isLoadingMatches {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 64)
+            } else if matches.isEmpty {
+                Text("No Game Center matches yet.")
+                    .font(LedgerTheme.uiFont(size: 15))
+                    .foregroundStyle(LedgerTheme.mutedInk)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(16)
+                    .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
+            } else {
+                ForEach(matches, id: \.match.matchID) { loaded in
+                    Button {
+                        onOpenMatch(loaded)
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("YOU vs \(loaded.opponentDisplayName.uppercased())")
+                                    .font(LedgerTheme.displayFont(size: 22, weight: .bold))
+                                    .foregroundStyle(LedgerTheme.ink)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.68)
+
+                                Text(loaded.isLocalTurn ? "Your turn" : "\(loaded.opponentDisplayName)'s turn")
+                                    .font(LedgerTheme.uiFont(size: 14, weight: .semibold))
+                                    .foregroundStyle(LedgerTheme.mutedInk)
+                            }
+
+                            Spacer()
+
+                            Image(systemName: "chevron.right")
+                                .foregroundStyle(LedgerTheme.rust)
+                        }
+                        .padding(15)
+                        .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var ledgerSummary: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Ledger")
+                .font(LedgerTheme.uiFont(size: 13, weight: .bold))
+                .foregroundStyle(LedgerTheme.mutedInk)
+                .textCase(.uppercase)
+
+            if ledgerCoordinator.ledgers.isEmpty {
+                Text("Completed Game Center matches will appear here.")
+                    .font(LedgerTheme.uiFont(size: 15))
+                    .foregroundStyle(LedgerTheme.mutedInk)
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
+            } else {
+                ForEach(ledgerCoordinator.ledgers, id: \.rival.id) { ledger in
+                    HStack {
+                        Text("YOU vs \(ledger.rival.displayName.uppercased())")
+                            .font(LedgerTheme.displayFont(size: 20, weight: .bold))
+                            .foregroundStyle(LedgerTheme.ink)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.68)
+
+                        Spacer()
+
+                        Text("\(ledger.userWins)-\(ledger.rivalWins)")
+                            .font(LedgerTheme.displayFont(size: 26, weight: .bold))
+                            .foregroundStyle(LedgerTheme.rust)
+                            .monospacedDigit()
+                    }
+                    .padding(15)
+                    .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
+                }
+            }
+        }
+    }
+
+    private func refresh() async {
+        guard session.authState.isAuthenticated else { return }
+        isLoadingMatches = true
+        defer { isLoadingMatches = false }
+
+        do {
+            await ledgerCoordinator.refresh()
+            let matchBoxes = try await session.loadMatches()
+            var gameCenterMatches: [GKTurnBasedMatch] = []
+            for box in matchBoxes {
+                let match = box.match
+                let status = match.status
+                if status == .open || status == .matching || status == .ended {
+                    gameCenterMatches.append(match)
+                }
+            }
+            var loaded: [GameCenterLoadedMatch] = []
+            for match in gameCenterMatches {
+                loaded.append(try await matchCoordinator.load(match: match, targetScore: selectedTargetScore))
+            }
+            matches = loaded.sorted { lhs, rhs in
+                if lhs.isLocalTurn != rhs.isLocalTurn {
+                    return lhs.isLocalTurn
+                }
+                return lhs.match.creationDate > rhs.match.creationDate
+            }
+        } catch {
+            localError = error.localizedDescription
+        }
+    }
+
+    private func loadAndOpen(match: GKTurnBasedMatch, targetScore: Int) async {
+        do {
+            let loaded = try await matchCoordinator.load(match: match, targetScore: targetScore)
+            onOpenMatch(loaded)
+        } catch {
+            localError = error.localizedDescription
+        }
+    }
+}
+
+private struct AuthenticationController: Identifiable {
+    let id = UUID()
+    let viewController: UIViewController
+}
+
+@MainActor
+private extension GKTurnBasedMatch {
+    func loadGameData() async throws -> Data? {
+        try await withCheckedThrowingContinuation { continuation in
+            loadMatchData { data, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: data)
+                }
+            }
+        }
+    }
+
+    func saveCurrentTurnData(_ data: Data) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            saveCurrentTurn(withMatch: data) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    func endTurn(to participant: GKTurnBasedParticipant, data: Data) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            endTurn(
+                withNextParticipants: [participant],
+                turnTimeout: GKTurnTimeoutDefault,
+                match: data
+            ) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    func endMatch(data: Data) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            endMatchInTurn(withMatch: data) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}
+
+private extension GKTurnBasedMatch {
+    @MainActor
+    func sendGameCenterReminder(to participant: GKTurnBasedParticipant) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            sendReminder(
+                to: [participant],
+                localizableMessageKey: "Your move in Shesh Besh.",
+                arguments: []
+            ) { error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}
+#endif

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -422,7 +422,8 @@ public struct GameCenterMatchmakerSheet: UIViewControllerRepresentable {
 
     public func updateUIViewController(_ uiViewController: GKTurnBasedMatchmakerViewController, context: Context) {}
 
-    public final class Coordinator: NSObject, @MainActor GKTurnBasedMatchmakerViewControllerDelegate {
+    @MainActor
+    public final class Coordinator: NSObject, @preconcurrency GKTurnBasedMatchmakerViewControllerDelegate {
         private let parent: GameCenterMatchmakerSheet
 
         init(parent: GameCenterMatchmakerSheet) {

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -337,7 +337,7 @@ private struct EmptyLedgerView: View {
     }
 }
 
-private struct LedgerBackground: View {
+struct LedgerBackground: View {
     var body: some View {
         Canvas { context, size in
             context.fill(Path(CGRect(origin: .zero, size: size)), with: .color(LedgerTheme.linen))
@@ -359,7 +359,7 @@ private struct LedgerBackground: View {
     }
 }
 
-private enum LedgerTheme {
+enum LedgerTheme {
     static let linen = Color(red: 0.937, green: 0.902, blue: 0.831)
     static let cream = Color(red: 0.929, green: 0.886, blue: 0.800)
     static let coffee = Color(red: 0.420, green: 0.290, blue: 0.180)

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -40,13 +40,18 @@ public final class LedgerCoordinator {
     public func startMatch(
         against rival: Rival,
         userPlays: Player,
-        config: MatchConfig
+        config: MatchConfig,
+        gameCenterMatchID: String? = nil,
+        gameIndex: Int = 0,
+        initialState: MatchState? = nil
     ) async throws -> ActiveMatch {
         let now = Date()
         let match = ActiveMatch(
             rivalID: rival.id,
+            gameCenterMatchID: gameCenterMatchID,
+            gameIndex: gameIndex,
             userPlayed: userPlays,
-            state: MatchEngine.newMatch(config: config),
+            state: initialState ?? MatchEngine.newMatch(config: config),
             startedAt: now,
             lastUpdatedAt: now
         )
@@ -89,6 +94,23 @@ public final class LedgerCoordinator {
         ledger(for: rivalID)?.rival
     }
 
+    public func rival(matchingGameCenterPlayerID playerID: String) -> Rival? {
+        ledgers
+            .map(\.rival)
+            .first { $0.gameCenterPlayerID == playerID }
+    }
+
+    public func activeMatch(gameCenterMatchID: String) -> ActiveMatch? {
+        ledgers
+            .compactMap(\.activeMatch)
+            .first { $0.gameCenterMatchID == gameCenterMatchID }
+    }
+
+    public func saveGameCenterMatch(_ match: ActiveMatch, rival: Rival) async throws {
+        try await store.upsertRival(rival)
+        try await saveActiveMatch(match)
+    }
+
     public func clearError() {
         lastErrorMessage = nil
     }
@@ -124,6 +146,8 @@ public final class LedgerCoordinator {
         let rivalPlayer = match.userPlayed.opponent
         return MatchRecord(
             rivalID: match.rivalID,
+            gameCenterMatchID: match.gameCenterMatchID,
+            gameIndex: match.gameIndex,
             userPlayed: match.userPlayed,
             winner: completion.winner == match.userPlayed ? .you : .rival,
             userScore: completion.finalScore.score(for: match.userPlayed),
@@ -148,8 +172,13 @@ public final class LedgerCoordinator {
         }
 
         guard !records.contains(where: { existingRecord in
-            existingRecord.startedAt == match.startedAt &&
-            existingRecord.finalSnapshot == match.state
+            if let matchID = match.gameCenterMatchID,
+               let existingMatchID = existingRecord.gameCenterMatchID {
+                return existingMatchID == matchID && existingRecord.gameIndex == match.gameIndex
+            }
+
+            return existingRecord.startedAt == match.startedAt &&
+                existingRecord.finalSnapshot == match.state
         }) else {
             return
         }

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -1,5 +1,10 @@
 import Foundation
+import SheshBeshGame
 import SwiftUI
+
+#if canImport(GameKit) && canImport(UIKit)
+@preconcurrency import GameKit
+#endif
 
 #if canImport(SheshBeshLedger)
 import SheshBeshLedger
@@ -11,6 +16,10 @@ public struct RootView: View {
     @State private var activeMatchViewModel: MatchViewModel?
     @State private var completedRecord: MatchRecord?
     @State private var routeError: String?
+    #if canImport(GameKit) && canImport(UIKit)
+    @State private var gameCenterSession = GameCenterSession()
+    @State private var activeGameCenterMatch: GameCenterLoadedMatch?
+    #endif
 
     public init() {
         _singleMatchViewModel = State(initialValue: nil)
@@ -44,8 +53,22 @@ public struct RootView: View {
                         )
                     }
             } else {
+                #if canImport(GameKit) && canImport(UIKit)
+                GameCenterHomeView(
+                    session: gameCenterSession,
+                    ledgerCoordinator: coordinator,
+                    matchCoordinator: GameCenterMatchCoordinator(ledgerCoordinator: coordinator),
+                    onOpenMatch: openGameCenterMatch
+                )
+                #else
                 HomeView(coordinator: coordinator, onOpenMatch: openMatch)
+                #endif
             }
+        }
+        .task {
+            #if canImport(GameKit) && canImport(UIKit)
+            configureGameCenterCallbacks()
+            #endif
         }
         .alert(
             "Ledger Error",
@@ -82,13 +105,16 @@ public struct RootView: View {
             localPlayer: match.userPlayed,
             opponentName: rival?.displayName ?? "Rival",
             activeMatchID: match.id,
-            initialState: match.state
+            initialState: match.state,
+            isOpponentAutoplayEnabled: true
         )
 
         viewModel.onStateChange = { [coordinator] state in
             let updated = ActiveMatch(
                 id: match.id,
                 rivalID: match.rivalID,
+                gameCenterMatchID: match.gameCenterMatchID,
+                gameIndex: match.gameIndex,
                 userPlayed: match.userPlayed,
                 state: state,
                 startedAt: match.startedAt,
@@ -107,6 +133,8 @@ public struct RootView: View {
             let completed = ActiveMatch(
                 id: match.id,
                 rivalID: match.rivalID,
+                gameCenterMatchID: match.gameCenterMatchID,
+                gameIndex: match.gameIndex,
                 userPlayed: match.userPlayed,
                 state: state,
                 startedAt: match.startedAt,
@@ -124,4 +152,78 @@ public struct RootView: View {
 
         activeMatchViewModel = viewModel
     }
+
+    #if canImport(GameKit) && canImport(UIKit)
+    private func configureGameCenterCallbacks() {
+        gameCenterSession.onTurnEvent = { match, _ in
+            Task {
+                await loadAndOpenGameCenterMatch(match)
+            }
+        }
+        gameCenterSession.onMatchEnded = { match in
+            Task {
+                await loadAndOpenGameCenterMatch(match)
+            }
+        }
+    }
+
+    private func loadAndOpenGameCenterMatch(_ match: GKTurnBasedMatch) async {
+        do {
+            let loaded = try await GameCenterMatchCoordinator(ledgerCoordinator: coordinator)
+                .load(match: match)
+            openGameCenterMatch(loaded)
+        } catch {
+            routeError = error.localizedDescription
+        }
+    }
+
+    private func openGameCenterMatch(_ loaded: GameCenterLoadedMatch) {
+        activeGameCenterMatch = loaded
+
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(
+                diceRoller: GameCenterDiceRoller(
+                    matchID: loaded.envelope.gameCenterMatchID,
+                    turnCounter: loaded.envelope.turnCounter,
+                    revision: loaded.envelope.revision
+                )
+            ),
+            config: loaded.envelope.config,
+            localPlayer: loaded.localPlayer,
+            opponentName: loaded.opponentDisplayName,
+            activeMatchID: loaded.activeMatch.id,
+            initialState: loaded.envelope.state,
+            isOpponentAutoplayEnabled: false
+        )
+
+        viewModel.onStateChange = { state in
+            Task {
+                do {
+                    guard let current = activeGameCenterMatch else { return }
+                    let updated = try await GameCenterMatchCoordinator(ledgerCoordinator: coordinator)
+                        .commit(state: state, for: current)
+                    activeGameCenterMatch = updated
+                } catch {
+                    routeError = error.localizedDescription
+                }
+            }
+        }
+
+        viewModel.onCompletion = { state in
+            Task {
+                do {
+                    guard let current = activeGameCenterMatch else { return }
+                    let updated = try await GameCenterMatchCoordinator(ledgerCoordinator: coordinator)
+                        .commit(state: state, for: current)
+                    activeGameCenterMatch = updated
+                    completedRecord = coordinator.latestCompletedRecord
+                } catch {
+                    routeError = error.localizedDescription
+                }
+            }
+        }
+
+        activeMatchViewModel = viewModel
+    }
+    #endif
 }

--- a/SheshBesh/SheshBesh.entitlements
+++ b/SheshBesh/SheshBesh.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.game-center</key>
+	<true/>
+</dict>
+</plist>

--- a/SheshBeshTests/GameCenterEnvelopeTests.swift
+++ b/SheshBeshTests/GameCenterEnvelopeTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SheshBeshApp
+import SheshBeshGame
+import Testing
+
+@Suite("Game Center envelope")
+struct GameCenterEnvelopeTests {
+    @Test("envelope round trips match state and player mapping")
+    func envelopeRoundTrip() throws {
+        let config = MatchConfig.tournament(targetScore: 7)
+        let envelope = GameCenterMatchEnvelope(
+            revision: 3,
+            turnCounter: 4,
+            gameCenterMatchID: "match-123",
+            playerMapping: GameCenterPlayerMapping(
+                whitePlayerID: "white-player",
+                blackPlayerID: "black-player",
+                whiteDisplayName: "Boris",
+                blackDisplayName: "Dan"
+            ),
+            config: config,
+            state: MatchEngine.newMatch(config: config)
+        )
+
+        let decoded = try GameCenterMatchEnvelope.decoded(from: envelope.encoded())
+
+        #expect(decoded == envelope)
+        #expect(decoded.playerMapping.player(forGameCenterID: "black-player") == .black)
+        #expect(decoded.playerMapping.displayName(for: .white) == "Boris")
+    }
+
+    @Test("future schema asks for app update")
+    func futureSchemaThrowsUpdateError() throws {
+        let config = MatchConfig.tournament(targetScore: 7)
+        let envelope = GameCenterMatchEnvelope(
+            schemaVersion: GameCenterMatchEnvelope.currentSchemaVersion + 1,
+            gameCenterMatchID: "match-123",
+            playerMapping: GameCenterPlayerMapping(
+                whitePlayerID: "white-player",
+                blackPlayerID: "black-player",
+                whiteDisplayName: "Boris",
+                blackDisplayName: "Dan"
+            ),
+            config: config,
+            state: MatchEngine.newMatch(config: config)
+        )
+
+        #expect(throws: GameCenterEnvelopeError.futureSchemaVersion(2)) {
+            try GameCenterMatchEnvelope.decoded(from: envelope.encoded())
+        }
+    }
+
+    @Test("deterministic dice fixture is stable")
+    func deterministicDiceFixture() {
+        let roller = GameCenterDiceRoller(matchID: "match-fixture-1", turnCounter: 4)
+        let rolls = (0..<10).map { _ in roller.rollDie() }
+
+        #expect(rolls == [1, 5, 2, 1, 6, 6, 5, 1, 1, 3])
+    }
+
+    @Test("revision participates in deterministic dice seed")
+    func revisionChangesDiceSequence() {
+        let roller = GameCenterDiceRoller(matchID: "match-fixture-1", turnCounter: 4, revision: 1)
+        let rolls = (0..<6).map { _ in roller.rollDie() }
+
+        #expect(rolls == [5, 4, 4, 6, 4, 2])
+    }
+}

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -87,6 +87,37 @@ struct LedgerCoordinatorTests {
         #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
         #expect(coordinator.ledger(for: rival.id)?.userWins == 1)
     }
+
+    @Test("Game Center completion is idempotent by match ID and game index")
+    @MainActor
+    func gameCenterCompletionIsIdempotent() async throws {
+        let store = InMemoryLedgerStore()
+        let coordinator = LedgerCoordinator(store: store)
+        let rival = Rival(displayName: "Dan", gameCenterPlayerID: "dan-gc")
+        let state = MatchState(
+            config: MatchConfig(targetScore: 1, usesDoublingCube: false),
+            score: MatchScore(white: 1, black: 0),
+            game: GameState(phase: .gameOver(GameResult(winner: .white, winKind: .single, cubeValue: 1))),
+            completion: MatchCompletion(winner: .white, finalScore: MatchScore(white: 1, black: 0))
+        )
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            gameCenterMatchID: "gc-match-1",
+            gameIndex: 0,
+            userPlayed: .white,
+            state: state
+        )
+
+        try await coordinator.saveGameCenterMatch(active, rival: rival)
+        try await coordinator.recordCompletion(of: active)
+        try await coordinator.recordCompletion(of: active)
+
+        let records = try await store.loadMatchRecords(rivalID: rival.id)
+
+        #expect(records.count == 1)
+        #expect(records.first?.gameCenterMatchID == "gc-match-1")
+        #expect(records.first?.gameIndex == 0)
+    }
 }
 
 private final class CompletionDiceRoller: DiceRolling, @unchecked Sendable {


### PR DESCRIPTION
Adds Game Center async turn-based multiplayer support with authentication, matchmaker UI, turn event handling, match data transport, reminders, and end-match handling. Introduces a versioned Game Center match envelope plus deterministic seeded dice for cross-device turn consistency. Extends the local ledger with Game Center player and match IDs so completed matches are idempotent by match ID and game index. Keeps GameKit isolated to the app layer and adds tests for envelope compatibility, dice fixtures, and ledger idempotency. Verification: `./scripts/test.sh`.