### PR TITLE
Add PR screenshot automation

### DIFF
--- a/.github/workflows/pr-screenshot.yml
+++ b/.github/workflows/pr-screenshot.yml
@@ -1,0 +1,80 @@
+name: PR Screenshot
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  screenshot:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Capture deterministic app screenshots
+        run: |
+          SCREENSHOT_DIR="$RUNNER_TEMP/pr-screenshots" \
+            RESULT_BUNDLE_PATH="$RUNNER_TEMP/pr-screenshots.xcresult" \
+            ./scripts/capture-pr-screenshots.sh
+
+      - name: Upload screenshot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-screenshots
+          path: ${{ runner.temp }}/pr-screenshots
+          if-no-files-found: error
+
+      - name: Write screenshot summary
+        run: |
+          {
+            echo "### PR screenshots"
+            echo
+            echo "Captured deterministic UI screenshots:"
+            for screenshot in "$RUNNER_TEMP"/pr-screenshots/*.png; do
+              echo "- $(basename "$screenshot")"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- shesh-besh-pr-screenshot -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              marker,
+              'PR screenshots were captured from the deterministic UI flow.',
+              '',
+              'Download the `pr-screenshots` artifact from this workflow run:',
+              runUrl,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(comment => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ This builds and tests the Swift package, then builds the checked-in Xcode
 project for iOS Simulator, catching drift between the SwiftPM and Xcode build
 paths. GitHub Actions runs this script for pushes and pull requests to `main`.
 
+Pull requests also run a dedicated screenshot workflow. It drives the
+deterministic UI test flow, exports the kept screenshots, uploads them as the
+`pr-screenshots` artifact, and links the artifact from the PR. To reproduce that
+capture locally:
+
+```sh
+./scripts/capture-pr-screenshots.sh
+```
+
 ```sh
 swift build
 swift test

--- a/SheshBeshUITests/SheshBeshUITests.swift
+++ b/SheshBeshUITests/SheshBeshUITests.swift
@@ -42,6 +42,27 @@ final class SheshBeshUITests: XCTestCase {
     }
 
     @MainActor
+    func testPRScreenshots() throws {
+        let app = configuredApp()
+        app.launch()
+
+        XCTAssertTrue(app.buttons["action-opening-roll"].waitForExistence(timeout: 5))
+        attachScreenshot(named: "01-opening-roll")
+
+        app.buttons["action-opening-roll"].tap()
+        XCTAssertTrue(element("die-1", in: app).waitForExistence(timeout: 2))
+        attachScreenshot(named: "02-rolled-6-1")
+
+        element("point-24", in: app).tap()
+        element("point-18", in: app).tap()
+        element("point-24", in: app).tap()
+        element("point-23", in: app).tap()
+
+        XCTAssertTrue(app.buttons["action-roll-dice"].waitForExistence(timeout: 4))
+        attachScreenshot(named: "03-your-turn")
+    }
+
+    @MainActor
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments = [
@@ -55,5 +76,13 @@ final class SheshBeshUITests: XCTestCase {
     @MainActor
     private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
         app.descendants(matching: .any)[identifier]
+    }
+
+    @MainActor
+    private func attachScreenshot(named name: String) {
+        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
     }
 }

--- a/scripts/capture-pr-screenshots.sh
+++ b/scripts/capture-pr-screenshots.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+IOS_TEST_DESTINATION="${IOS_TEST_DESTINATION:-platform=iOS Simulator,name=iPhone 17,OS=latest}"
+SCREENSHOT_DIR="${SCREENSHOT_DIR:-$ROOT_DIR/.context/pr-screenshots}"
+RESULT_BUNDLE_PATH="${RESULT_BUNDLE_PATH:-$ROOT_DIR/.context/pr-screenshots.xcresult}"
+ATTACHMENTS_DIR="$SCREENSHOT_DIR/.xcresult-attachments"
+
+rm -rf "$SCREENSHOT_DIR" "$RESULT_BUNDLE_PATH"
+mkdir -p "$ATTACHMENTS_DIR"
+
+xcodebuild \
+  -project SheshBesh.xcodeproj \
+  -scheme SheshBesh \
+  -destination "$IOS_TEST_DESTINATION" \
+  -only-testing:SheshBeshUITests/SheshBeshUITests/testPRScreenshots \
+  -resultBundlePath "$RESULT_BUNDLE_PATH" \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+
+xcrun xcresulttool export attachments \
+  --path "$RESULT_BUNDLE_PATH" \
+  --output-path "$ATTACHMENTS_DIR"
+
+screenshot_count=0
+manifest_path="$ATTACHMENTS_DIR/manifest.json"
+if command -v jq >/dev/null 2>&1 && [[ -f "$manifest_path" ]]; then
+  while IFS=$'\t' read -r exported_name suggested_name; do
+    source_path="$ATTACHMENTS_DIR/$exported_name"
+    [[ -f "$source_path" ]] || continue
+
+    extension="${suggested_name##*.}"
+    filename="${suggested_name%.*}"
+    filename="${filename%%_0_*}"
+    cp "$source_path" "$SCREENSHOT_DIR/$filename.$extension"
+    screenshot_count=$((screenshot_count + 1))
+  done < <(
+    jq -r '.[] | .attachments[] | [.exportedFileName, .suggestedHumanReadableName] | @tsv' \
+      "$manifest_path"
+  )
+else
+  while IFS= read -r -d '' attachment; do
+    filename="$(basename "$attachment")"
+    cp "$attachment" "$SCREENSHOT_DIR/$filename"
+    screenshot_count=$((screenshot_count + 1))
+  done < <(
+    find "$ATTACHMENTS_DIR" \
+    -maxdepth 2 \
+    -type f \
+    \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' \) \
+    -print0
+  )
+fi
+
+if [[ "$screenshot_count" -eq 0 ]]; then
+  echo "No screenshots were exported from $RESULT_BUNDLE_PATH" >&2
+  exit 1
+fi
+
+rm -rf "$ATTACHMENTS_DIR"
+
+find "$SCREENSHOT_DIR" \
+  -maxdepth 1 \
+  -type f \
+  \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' \) \
+  -print


### PR DESCRIPTION
Adds a PR-only GitHub Actions workflow that captures deterministic app screenshots and uploads them as a pr-screenshots artifact. Adds a focused UI test and script to generate readable screenshot files from the xcresult attachments. Documents the local screenshot capture command in the README. Verification: ./scripts/test.sh passed on rerun after one simulator restart flake.