### PR TITLE
Add rivalry launch actions

### DIFF
--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -725,25 +725,7 @@ public struct GameCenterHomeView: View {
         isWorking = true
         Task {
             do {
-                let rival: Rival
-                if let existingRival = ledgerCoordinator.ledgers
-                    .map(\.rival)
-                    .first(where: { $0.gameCenterPlayerID == nil && $0.displayName == "Random Dan" }) {
-                    rival = existingRival
-                } else {
-                    rival = try await ledgerCoordinator.addRival(displayName: "Random Dan")
-                }
-                let match: ActiveMatch
-                if let activeMatch = ledgerCoordinator.ledger(for: rival.id)?.activeMatch {
-                    match = activeMatch
-                } else {
-                    match = try await ledgerCoordinator.startMatch(
-                        against: rival,
-                        userPlays: .white,
-                        config: .tournament(targetScore: 1)
-                    )
-                }
-                onOpenLocalMatch(match)
+                onOpenLocalMatch(try await ledgerCoordinator.startAIRivalry())
             } catch {
                 localError = error.localizedDescription
             }
@@ -836,7 +818,7 @@ private struct EmptyGameCenterLedgerView: View {
                 .lineLimit(2)
                 .minimumScaleFactor(0.72)
 
-            Text("Practice against Random Dan now, or invite a friend through Game Center.")
+            Text("Practice against AI now, or invite a friend through Game Center.")
                 .font(LedgerTheme.uiFont(size: 15))
                 .foregroundStyle(LedgerTheme.mutedInk)
                 .fixedSize(horizontal: false, vertical: true)

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -796,7 +796,10 @@ public struct GameCenterHomeView: View {
             return
         }
 
+        guard !isWorking else { return }
+        isWorking = true
         Task {
+            defer { isWorking = false }
             await refresh()
             if let loaded = matches.first(where: { $0.match.matchID == gameCenterMatchID }) {
                 onOpenMatch(loaded)

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -504,10 +504,12 @@ public struct GameCenterHomeView: View {
     public let session: GameCenterSession
     public let ledgerCoordinator: LedgerCoordinator
     public let matchCoordinator: GameCenterMatchCoordinator
+    public let onOpenLocalMatch: (ActiveMatch) -> Void
     public let onOpenMatch: (GameCenterLoadedMatch) -> Void
 
     @State private var matches: [GameCenterLoadedMatch] = []
     @State private var isLoadingMatches = false
+    @State private var isWorking = false
     @State private var isShowingMatchmaker = false
     @State private var isSelectingTargetScore = false
     @State private var selectedTargetScore = 7
@@ -517,11 +519,13 @@ public struct GameCenterHomeView: View {
         session: GameCenterSession,
         ledgerCoordinator: LedgerCoordinator,
         matchCoordinator: GameCenterMatchCoordinator,
+        onOpenLocalMatch: @escaping (ActiveMatch) -> Void,
         onOpenMatch: @escaping (GameCenterLoadedMatch) -> Void
     ) {
         self.session = session
         self.ledgerCoordinator = ledgerCoordinator
         self.matchCoordinator = matchCoordinator
+        self.onOpenLocalMatch = onOpenLocalMatch
         self.onOpenMatch = onOpenMatch
     }
 
@@ -533,12 +537,29 @@ public struct GameCenterHomeView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     header
-                    authPanel
+                    RivalryLaunchActions(
+                        primaryTitle: "Practice vs AI",
+                        primarySystemImage: "cpu",
+                        secondaryTitle: "Invite Friend",
+                        secondarySystemImage: "person.badge.plus",
+                        onPrimary: startAIRivalry,
+                        onSecondary: startGameCenterInvite
+                    )
 
-                    if session.authState.isAuthenticated {
-                        matchControls
-                        matchList
-                        ledgerSummary
+                    if !session.authState.isAuthenticated {
+                        authPanel
+                    }
+
+                    if ledgerCoordinator.ledgers.isEmpty {
+                        EmptyGameCenterLedgerView()
+                    } else {
+                        RivalryStack(
+                            ledgers: ledgerCoordinator.ledgers,
+                            onStart: startMatch,
+                            onResume: resumeMatch,
+                            startTitle: startTitle,
+                            startSystemImage: startSystemImage
+                        )
                     }
                 }
                 .padding(.horizontal, 18)
@@ -613,7 +634,7 @@ public struct GameCenterHomeView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.78)
 
-            Text("Game Center async matches")
+            Text("AI practice and Game Center matches")
                 .font(LedgerTheme.uiFont(size: 14, weight: .semibold))
                 .foregroundStyle(LedgerTheme.mutedInk)
                 .textCase(.uppercase)
@@ -668,123 +689,13 @@ public struct GameCenterHomeView: View {
         session.authState == .authenticating ? "Connecting" : "Sign in"
     }
 
-    private var matchControls: some View {
-        HStack(spacing: 10) {
-            Button {
-                isSelectingTargetScore = true
-            } label: {
-                Label("New match", systemImage: "plus")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(LedgerTheme.rust)
-
-            Button {
-                Task { await refresh() }
-            } label: {
-                Label("Refresh", systemImage: "arrow.clockwise")
-                    .labelStyle(.iconOnly)
-                    .frame(width: 44, height: 44)
-            }
-            .buttonStyle(.bordered)
-            .tint(LedgerTheme.coffee)
-            .disabled(isLoadingMatches)
-        }
-    }
-
-    private var matchList: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Matches")
-                .font(LedgerTheme.uiFont(size: 13, weight: .bold))
-                .foregroundStyle(LedgerTheme.mutedInk)
-                .textCase(.uppercase)
-
-            if isLoadingMatches {
-                ProgressView()
-                    .frame(maxWidth: .infinity, minHeight: 64)
-            } else if matches.isEmpty {
-                Text("No Game Center matches yet.")
-                    .font(LedgerTheme.uiFont(size: 15))
-                    .foregroundStyle(LedgerTheme.mutedInk)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(16)
-                    .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
-            } else {
-                ForEach(matches, id: \.match.matchID) { loaded in
-                    Button {
-                        onOpenMatch(loaded)
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("YOU vs \(loaded.opponentDisplayName.uppercased())")
-                                    .font(LedgerTheme.displayFont(size: 22, weight: .bold))
-                                    .foregroundStyle(LedgerTheme.ink)
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.68)
-
-                                Text(loaded.isLocalTurn ? "Your turn" : "\(loaded.opponentDisplayName)'s turn")
-                                    .font(LedgerTheme.uiFont(size: 14, weight: .semibold))
-                                    .foregroundStyle(LedgerTheme.mutedInk)
-                            }
-
-                            Spacer()
-
-                            Image(systemName: "chevron.right")
-                                .foregroundStyle(LedgerTheme.rust)
-                        }
-                        .padding(15)
-                        .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-        }
-    }
-
-    private var ledgerSummary: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Ledger")
-                .font(LedgerTheme.uiFont(size: 13, weight: .bold))
-                .foregroundStyle(LedgerTheme.mutedInk)
-                .textCase(.uppercase)
-
-            if ledgerCoordinator.ledgers.isEmpty {
-                Text("Completed Game Center matches will appear here.")
-                    .font(LedgerTheme.uiFont(size: 15))
-                    .foregroundStyle(LedgerTheme.mutedInk)
-                    .padding(16)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
-            } else {
-                ForEach(ledgerCoordinator.ledgers, id: \.rival.id) { ledger in
-                    HStack {
-                        Text("YOU vs \(ledger.rival.displayName.uppercased())")
-                            .font(LedgerTheme.displayFont(size: 20, weight: .bold))
-                            .foregroundStyle(LedgerTheme.ink)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.68)
-
-                        Spacer()
-
-                        Text("\(ledger.userWins)-\(ledger.rivalWins)")
-                            .font(LedgerTheme.displayFont(size: 26, weight: .bold))
-                            .foregroundStyle(LedgerTheme.rust)
-                            .monospacedDigit()
-                    }
-                    .padding(15)
-                    .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
-                }
-            }
-        }
-    }
-
     private func refresh() async {
+        await ledgerCoordinator.refresh()
         guard session.authState.isAuthenticated else { return }
         isLoadingMatches = true
         defer { isLoadingMatches = false }
 
         do {
-            await ledgerCoordinator.refresh()
             let matchBoxes = try await session.loadMatches()
             var gameCenterMatches: [GKTurnBasedMatch] = []
             for box in matchBoxes {
@@ -809,6 +720,100 @@ public struct GameCenterHomeView: View {
         }
     }
 
+    private func startAIRivalry() {
+        guard !isWorking else { return }
+        isWorking = true
+        Task {
+            do {
+                let rival: Rival
+                if let existingRival = ledgerCoordinator.ledgers
+                    .map(\.rival)
+                    .first(where: { $0.gameCenterPlayerID == nil && $0.displayName == "Random Dan" }) {
+                    rival = existingRival
+                } else {
+                    rival = try await ledgerCoordinator.addRival(displayName: "Random Dan")
+                }
+                let match: ActiveMatch
+                if let activeMatch = ledgerCoordinator.ledger(for: rival.id)?.activeMatch {
+                    match = activeMatch
+                } else {
+                    match = try await ledgerCoordinator.startMatch(
+                        against: rival,
+                        userPlays: .white,
+                        config: .tournament(targetScore: 1)
+                    )
+                }
+                onOpenLocalMatch(match)
+            } catch {
+                localError = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
+    private func startGameCenterInvite() {
+        guard session.authState.isAuthenticated else {
+            session.authenticate()
+            return
+        }
+        isSelectingTargetScore = true
+    }
+
+    private func startMatch(for ledger: RivalLedger) {
+        if ledger.rival.gameCenterPlayerID != nil {
+            startGameCenterInvite()
+        } else {
+            startLocalMatch(for: ledger)
+        }
+    }
+
+    private func startLocalMatch(for ledger: RivalLedger) {
+        guard !isWorking else { return }
+        isWorking = true
+        Task {
+            do {
+                let match = try await ledgerCoordinator.startMatch(
+                    against: ledger.rival,
+                    userPlays: ledger.totalMatches.isMultiple(of: 2) ? .white : .black,
+                    config: .tournament(targetScore: 7)
+                )
+                onOpenLocalMatch(match)
+            } catch {
+                localError = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
+    private func resumeMatch(_ match: ActiveMatch) {
+        guard let gameCenterMatchID = match.gameCenterMatchID else {
+            onOpenLocalMatch(match)
+            return
+        }
+
+        if let loaded = matches.first(where: { $0.match.matchID == gameCenterMatchID }) {
+            onOpenMatch(loaded)
+            return
+        }
+
+        Task {
+            await refresh()
+            if let loaded = matches.first(where: { $0.match.matchID == gameCenterMatchID }) {
+                onOpenMatch(loaded)
+            } else {
+                localError = "This Game Center match is not available right now."
+            }
+        }
+    }
+
+    private func startTitle(for ledger: RivalLedger) -> String {
+        ledger.rival.gameCenterPlayerID == nil ? "Start match" : "Invite again"
+    }
+
+    private func startSystemImage(for ledger: RivalLedger) -> String {
+        ledger.rival.gameCenterPlayerID == nil ? "play.fill" : "person.badge.plus"
+    }
+
     private func loadAndOpen(match: GKTurnBasedMatch, targetScore: Int) async {
         do {
             let loaded = try await matchCoordinator.load(match: match, targetScore: targetScore)
@@ -816,6 +821,30 @@ public struct GameCenterHomeView: View {
         } catch {
             localError = error.localizedDescription
         }
+    }
+}
+
+private struct EmptyGameCenterLedgerView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Start a rivalry")
+                .font(LedgerTheme.displayFont(size: 26, weight: .bold))
+                .foregroundStyle(LedgerTheme.ink)
+                .lineLimit(2)
+                .minimumScaleFactor(0.72)
+
+            Text("Practice against Random Dan now, or invite a friend through Game Center.")
+                .font(LedgerTheme.uiFont(size: 15))
+                .foregroundStyle(LedgerTheme.mutedInk)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(LedgerTheme.cream, in: RoundedRectangle(cornerRadius: 7))
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(LedgerTheme.brass.opacity(0.72), lineWidth: 1)
+        )
     }
 }
 

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -30,21 +30,25 @@ public struct HomeView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     header
-
-                    if coordinator.ledgers.isEmpty {
-                        EmptyLedgerView {
+                    RivalryLaunchActions(
+                        primaryTitle: "Practice vs AI",
+                        primarySystemImage: "cpu",
+                        secondaryTitle: "Add Rival",
+                        secondarySystemImage: "person.badge.plus",
+                        onPrimary: startAIRivalry,
+                        onSecondary: {
                             newRivalName = ""
                             isAddingRival = true
                         }
+                    )
+
+                    if coordinator.ledgers.isEmpty {
+                        EmptyLedgerView()
                     } else {
                         RivalryStack(
                             ledgers: coordinator.ledgers,
                             onStart: startMatch,
-                            onResume: onOpenMatch,
-                            onAddRival: {
-                                newRivalName = ""
-                                isAddingRival = true
-                            }
+                            onResume: onOpenMatch
                         )
                     }
                 }
@@ -114,6 +118,37 @@ public struct HomeView: View {
         }
     }
 
+    private func startAIRivalry() {
+        guard !isWorking else { return }
+        isWorking = true
+        Task {
+            do {
+                let rival: Rival
+                if let existingRival = coordinator.ledgers
+                    .map(\.rival)
+                    .first(where: { $0.gameCenterPlayerID == nil && $0.displayName == "Random Dan" }) {
+                    rival = existingRival
+                } else {
+                    rival = try await coordinator.addRival(displayName: "Random Dan")
+                }
+                let match: ActiveMatch
+                if let activeMatch = coordinator.ledger(for: rival.id)?.activeMatch {
+                    match = activeMatch
+                } else {
+                    match = try await coordinator.startMatch(
+                        against: rival,
+                        userPlays: .white,
+                        config: .tournament(targetScore: 1)
+                    )
+                }
+                onOpenMatch(match)
+            } catch {
+                localError = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
     private func startMatch(for ledger: RivalLedger) {
         guard !isWorking else { return }
         isWorking = true
@@ -133,11 +168,55 @@ public struct HomeView: View {
     }
 }
 
-private struct RivalryStack: View {
+struct RivalryLaunchActions: View {
+    let primaryTitle: String
+    let primarySystemImage: String
+    let secondaryTitle: String
+    let secondarySystemImage: String
+    let onPrimary: () -> Void
+    let onSecondary: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button(action: onPrimary) {
+                Label(primaryTitle, systemImage: primarySystemImage)
+                    .font(LedgerTheme.uiFont(size: 15, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(LedgerTheme.rust)
+            .accessibilityIdentifier("home-new-ai-rival")
+
+            Button(action: onSecondary) {
+                Label(secondaryTitle, systemImage: secondarySystemImage)
+                    .font(LedgerTheme.uiFont(size: 15, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
+            .buttonStyle(.bordered)
+            .tint(LedgerTheme.coffee)
+            .accessibilityIdentifier("home-new-game-center-rival")
+        }
+    }
+}
+
+struct RivalryStack: View {
     let ledgers: [RivalLedger]
     let onStart: (RivalLedger) -> Void
     let onResume: (ActiveMatch) -> Void
-    let onAddRival: () -> Void
+    var startTitle: (RivalLedger) -> String = { _ in "Start match" }
+    var startSystemImage: (RivalLedger) -> String = { _ in "play.fill" }
+    var resumeTitle: (RivalLedger) -> String = { ledger in
+        ledger.activeMatch?.gameCenterMatchID == nil ? "Resume match" : "Open turn"
+    }
+    var resumeSystemImage: (RivalLedger) -> String = { ledger in
+        ledger.activeMatch?.gameCenterMatchID == nil ? "arrow.uturn.forward" : "arrow.turn.up.right"
+    }
 
     var body: some View {
         VStack(spacing: 14) {
@@ -145,6 +224,10 @@ private struct RivalryStack: View {
                 RivalryCard(
                     ledger: hero,
                     isHero: true,
+                    startTitle: startTitle(hero),
+                    startSystemImage: startSystemImage(hero),
+                    resumeTitle: resumeTitle(hero),
+                    resumeSystemImage: resumeSystemImage(hero),
                     onStart: { onStart(hero) },
                     onResume: {
                         if let match = hero.activeMatch {
@@ -158,6 +241,10 @@ private struct RivalryStack: View {
                 RivalryCard(
                     ledger: ledger,
                     isHero: false,
+                    startTitle: startTitle(ledger),
+                    startSystemImage: startSystemImage(ledger),
+                    resumeTitle: resumeTitle(ledger),
+                    resumeSystemImage: resumeSystemImage(ledger),
                     onStart: { onStart(ledger) },
                     onResume: {
                         if let match = ledger.activeMatch {
@@ -166,16 +253,6 @@ private struct RivalryStack: View {
                     }
                 )
             }
-
-            Button(action: onAddRival) {
-                Label("New rival", systemImage: "plus")
-                    .font(LedgerTheme.uiFont(size: 16, weight: .semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(LedgerTheme.rust)
-            .accessibilityIdentifier("home-new-rival")
         }
     }
 }
@@ -183,6 +260,10 @@ private struct RivalryStack: View {
 private struct RivalryCard: View {
     let ledger: RivalLedger
     let isHero: Bool
+    let startTitle: String
+    let startSystemImage: String
+    let resumeTitle: String
+    let resumeSystemImage: String
     let onStart: () -> Void
     let onResume: () -> Void
 
@@ -220,7 +301,7 @@ private struct RivalryCard: View {
 
             if ledger.activeMatch == nil {
                 Button(action: onStart) {
-                    Label("Start match", systemImage: "play.fill")
+                    Label(startTitle, systemImage: startSystemImage)
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
@@ -228,7 +309,7 @@ private struct RivalryCard: View {
                 .accessibilityIdentifier("start-match-\(ledger.rival.id.uuidString)")
             } else {
                 Button(action: onResume) {
-                    Label("Resume match", systemImage: "arrow.uturn.forward")
+                    Label(resumeTitle, systemImage: resumeSystemImage)
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
@@ -305,8 +386,6 @@ private struct MetricPill: View {
 }
 
 private struct EmptyLedgerView: View {
-    let onAddRival: () -> Void
-
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Start a head-to-head ledger")
@@ -319,13 +398,6 @@ private struct EmptyLedgerView: View {
                 .font(LedgerTheme.uiFont(size: 15))
                 .foregroundStyle(LedgerTheme.mutedInk)
                 .fixedSize(horizontal: false, vertical: true)
-
-            Button(action: onAddRival) {
-                Label("New rival", systemImage: "plus")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(LedgerTheme.rust)
         }
         .padding(18)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -123,25 +123,7 @@ public struct HomeView: View {
         isWorking = true
         Task {
             do {
-                let rival: Rival
-                if let existingRival = coordinator.ledgers
-                    .map(\.rival)
-                    .first(where: { $0.gameCenterPlayerID == nil && $0.displayName == "Random Dan" }) {
-                    rival = existingRival
-                } else {
-                    rival = try await coordinator.addRival(displayName: "Random Dan")
-                }
-                let match: ActiveMatch
-                if let activeMatch = coordinator.ledger(for: rival.id)?.activeMatch {
-                    match = activeMatch
-                } else {
-                    match = try await coordinator.startMatch(
-                        against: rival,
-                        userPlays: .white,
-                        config: .tournament(targetScore: 1)
-                    )
-                }
-                onOpenMatch(match)
+                onOpenMatch(try await coordinator.startAIRivalry())
             } catch {
                 localError = error.localizedDescription
             }

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -9,6 +9,9 @@ import SheshBeshLedger
 @MainActor
 @Observable
 public final class LedgerCoordinator {
+    private static let quickAIRivalDisplayName = "Random Dan"
+    private static let quickAIMatchConfig = MatchConfig.tournament(targetScore: 1)
+
     @ObservationIgnored private let store: any LedgerStore
 
     public private(set) var ledgers: [RivalLedger] = []
@@ -86,6 +89,31 @@ public final class LedgerCoordinator {
         return rival
     }
 
+    public func startAIRivalry() async throws -> ActiveMatch {
+        await refresh()
+
+        let rival: Rival
+        if let existingRival = ledgers
+            .map(\.rival)
+            .first(where: Self.isQuickAIRival) {
+            rival = existingRival
+        } else {
+            rival = Rival(displayName: Self.quickAIRivalDisplayName)
+            try await store.upsertRival(rival)
+            await refresh()
+        }
+
+        if let activeMatch = ledger(for: rival.id)?.activeMatch {
+            return activeMatch
+        }
+
+        return try await startMatch(
+            against: rival,
+            userPlays: .white,
+            config: Self.quickAIMatchConfig
+        )
+    }
+
     public func ledger(for rivalID: Rival.ID) -> RivalLedger? {
         ledgers.first { $0.rival.id == rivalID }
     }
@@ -113,6 +141,10 @@ public final class LedgerCoordinator {
 
     public func clearError() {
         lastErrorMessage = nil
+    }
+
+    private static func isQuickAIRival(_ rival: Rival) -> Bool {
+        rival.gameCenterPlayerID == nil && rival.displayName == quickAIRivalDisplayName
     }
 
     private static func sortLedgers(_ lhs: RivalLedger, _ rhs: RivalLedger) -> Bool {

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -60,6 +60,7 @@ public struct RootView: View {
                     session: gameCenterSession,
                     ledgerCoordinator: coordinator,
                     matchCoordinator: GameCenterMatchCoordinator(ledgerCoordinator: coordinator),
+                    onOpenLocalMatch: openMatch,
                     onOpenMatch: openGameCenterMatch
                 )
                 #else

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -118,6 +118,25 @@ struct LedgerCoordinatorTests {
         #expect(records.first?.gameCenterMatchID == "gc-match-1")
         #expect(records.first?.gameIndex == 0)
     }
+
+    @Test("AI rivalry starts or resumes a Random Dan quick match")
+    @MainActor
+    func aiRivalryStartsOrResumesQuickMatch() async throws {
+        let store = InMemoryLedgerStore()
+        let coordinator = LedgerCoordinator(store: store)
+
+        let firstMatch = try await coordinator.startAIRivalry()
+        let rival = try #require(coordinator.rival(for: firstMatch.rivalID))
+        let secondMatch = try await coordinator.startAIRivalry()
+        let rivals = try await store.loadRivals()
+
+        #expect(rivals.count == 1)
+        #expect(rival.displayName == "Random Dan")
+        #expect(rival.gameCenterPlayerID == nil)
+        #expect(firstMatch.id == secondMatch.id)
+        #expect(firstMatch.userPlayed == .white)
+        #expect(firstMatch.state.config.targetScore == 1)
+    }
 }
 
 private final class CompletionDiceRoller: DiceRolling, @unchecked Sendable {


### PR DESCRIPTION
Adds top-level rivalry actions for Practice vs AI and Invite Friend, with the Game Center home showing one unified rivalry list for AI and Game Center rivals. Guards Game Center resume refreshes so repeated taps do not start overlapping refresh work. Centralizes quick AI rivalry creation/resume behavior in LedgerCoordinator, including the Random Dan rival and one-point match configuration. Verification: ./scripts/test.sh, swift test, xcodebuild -project SheshBesh.xcodeproj -scheme SheshBesh -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build.