### PR TITLE
ci: make PR screenshots manual

### DIFF
--- a/.github/workflows/pr-screenshot.yml
+++ b/.github/workflows/pr-screenshot.yml
@@ -1,8 +1,6 @@
 name: PR Screenshot
 
 on:
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Make the PR Screenshot workflow manual-only by removing its automatic pull_request trigger. The existing workflow_dispatch trigger remains, and the guarded PR comment step is left unchanged.

## Test plan
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-screenshot.yml'); puts 'YAML OK'"
- ./scripts/test.sh