### PR TITLE
Rename local AI opponent label

### DIFF
--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -9,7 +9,8 @@ import SheshBeshLedger
 @MainActor
 @Observable
 public final class LedgerCoordinator {
-    private static let quickAIRivalDisplayName = "Random Dan"
+    private static let quickAIRivalDisplayName = "Local AI"
+    private static let legacyQuickAIRivalDisplayName = "Random Dan"
     private static let quickAIMatchConfig = MatchConfig.tournament(targetScore: 1)
 
     @ObservationIgnored private let store: any LedgerStore
@@ -96,7 +97,15 @@ public final class LedgerCoordinator {
         if let existingRival = ledgers
             .map(\.rival)
             .first(where: Self.isQuickAIRival) {
-            rival = existingRival
+            if existingRival.displayName == Self.quickAIRivalDisplayName {
+                rival = existingRival
+            } else {
+                var renamedRival = existingRival
+                renamedRival.displayName = Self.quickAIRivalDisplayName
+                try await store.upsertRival(renamedRival)
+                await refresh()
+                rival = renamedRival
+            }
         } else {
             rival = Rival(displayName: Self.quickAIRivalDisplayName)
             try await store.upsertRival(rival)
@@ -144,7 +153,8 @@ public final class LedgerCoordinator {
     }
 
     private static func isQuickAIRival(_ rival: Rival) -> Bool {
-        rival.gameCenterPlayerID == nil && rival.displayName == quickAIRivalDisplayName
+        rival.gameCenterPlayerID == nil &&
+            (rival.displayName == quickAIRivalDisplayName || rival.displayName == legacyQuickAIRivalDisplayName)
     }
 
     private static func sortLedgers(_ lhs: RivalLedger, _ rhs: RivalLedger) -> Bool {

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -6,7 +6,7 @@ import SheshBeshGame
 @Observable
 public final class MatchViewModel {
     private let engine: MatchEngine
-    private let opponentController: RandomDanOpponent
+    private let opponentController: LocalAIOpponent
     private let opponentDelay: @Sendable () async -> Void
     @ObservationIgnored private var opponentTask: Task<Void, Never>?
 
@@ -32,11 +32,11 @@ public final class MatchViewModel {
         engine: MatchEngine = MatchEngine(),
         config: MatchConfig = .tournament(targetScore: 1),
         localPlayer: Player = .white,
-        opponentName: String = "Random Dan",
+        opponentName: String = "Local AI",
         activeMatchID: UUID = UUID(),
         initialState: MatchState? = nil,
         isOpponentAutoplayEnabled: Bool = true,
-        opponentController: RandomDanOpponent = RandomDanOpponent(),
+        opponentController: LocalAIOpponent = LocalAIOpponent(),
         opponentDelay: @escaping @Sendable () async -> Void = {
             let nanoseconds = UInt64(Double.random(in: 0.8...1.2) * 1_000_000_000)
             try? await Task.sleep(nanoseconds: nanoseconds)
@@ -383,7 +383,7 @@ public final class MatchViewModel {
     }
 }
 
-public struct RandomDanOpponent: Sendable {
+public struct LocalAIOpponent: Sendable {
     private let randomIndex: @Sendable (Int) -> Int
 
     public init(randomIndex: @escaping @Sendable (Int) -> Int = { upperBound in

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -119,7 +119,7 @@ struct LedgerCoordinatorTests {
         #expect(records.first?.gameIndex == 0)
     }
 
-    @Test("AI rivalry starts or resumes a Random Dan quick match")
+    @Test("AI rivalry starts or resumes a Local AI quick match")
     @MainActor
     func aiRivalryStartsOrResumesQuickMatch() async throws {
         let store = InMemoryLedgerStore()
@@ -131,11 +131,27 @@ struct LedgerCoordinatorTests {
         let rivals = try await store.loadRivals()
 
         #expect(rivals.count == 1)
-        #expect(rival.displayName == "Random Dan")
+        #expect(rival.displayName == "Local AI")
         #expect(rival.gameCenterPlayerID == nil)
         #expect(firstMatch.id == secondMatch.id)
         #expect(firstMatch.userPlayed == .white)
         #expect(firstMatch.state.config.targetScore == 1)
+    }
+
+    @Test("AI rivalry renames legacy Random Dan rival to Local AI")
+    @MainActor
+    func aiRivalryRenamesLegacyRandomDanRival() async throws {
+        let legacyRival = Rival(displayName: "Random Dan")
+        let store = InMemoryLedgerStore(rivals: [legacyRival])
+        let coordinator = LedgerCoordinator(store: store)
+
+        let match = try await coordinator.startAIRivalry()
+        let rivals = try await store.loadRivals()
+
+        #expect(rivals.count == 1)
+        #expect(rivals.first?.id == legacyRival.id)
+        #expect(rivals.first?.displayName == "Local AI")
+        #expect(match.rivalID == legacyRival.id)
     }
 }
 

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -4,14 +4,14 @@ import Testing
 
 @Suite("Match view model")
 struct MatchViewModelTests {
-    @Test("default match is a one point Random Dan quick match")
+    @Test("default match is a one point Local AI quick match")
     @MainActor
-    func defaultMatchIsRandomDanQuickMatch() {
+    func defaultMatchIsLocalAIQuickMatch() {
         let viewModel = MatchViewModel(isOpponentAutoplayEnabled: false)
 
         #expect(viewModel.state.config.targetScore == 1)
         #expect(viewModel.localPlayer == .white)
-        #expect(viewModel.opponentName == "Random Dan")
+        #expect(viewModel.opponentName == "Local AI")
     }
 
     @Test("opening roll is applied through the engine")
@@ -148,13 +148,13 @@ struct MatchViewModelTests {
         }
     }
 
-    @Test("opening roll can hand first turn to Random Dan")
+    @Test("opening roll can hand first turn to Local AI")
     @MainActor
-    func openingRollCanHandFirstTurnToDan() async {
+    func openingRollCanHandFirstTurnToLocalAI() async {
         let viewModel = MatchViewModel(
             engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 6])),
             config: .tournament(targetScore: 1),
-            opponentController: RandomDanOpponent(randomIndex: { _ in 0 }),
+            opponentController: LocalAIOpponent(randomIndex: { _ in 0 }),
             opponentDelay: {}
         )
 
@@ -173,13 +173,13 @@ struct MatchViewModelTests {
         #expect(!viewModel.isOpponentThinking)
     }
 
-    @Test("Random Dan rolls and moves after local turn ends")
+    @Test("Local AI rolls and moves after local turn ends")
     @MainActor
-    func randomDanRollsAndMovesAfterLocalTurnEnds() async {
+    func localAIRollsAndMovesAfterLocalTurnEnds() async {
         let viewModel = MatchViewModel(
             engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 3, 2])),
             config: .tournament(targetScore: 1),
-            opponentController: RandomDanOpponent(randomIndex: { _ in 0 }),
+            opponentController: LocalAIOpponent(randomIndex: { _ in 0 }),
             opponentDelay: {}
         )
 
@@ -199,9 +199,9 @@ struct MatchViewModelTests {
         #expect(viewModel.pipCount(for: .black) < 167)
     }
 
-    @Test("Random Dan passes when blocked")
+    @Test("Local AI passes when blocked")
     @MainActor
-    func randomDanPassesWhenBlocked() async throws {
+    func localAIPassesWhenBlocked() async throws {
         var board = Board.empty()
         try board.setPoint(PointID(rawValue: 5)!, owner: .white, count: 2)
         try board.setPoint(PointID(rawValue: 6)!, owner: .white, count: 2)
@@ -232,12 +232,12 @@ struct MatchViewModelTests {
 
         #expect(passed)
         #expect(viewModel.lastError == nil)
-        #expect(viewModel.phaseTitle == "Random Dan had no legal moves")
+        #expect(viewModel.phaseTitle == "Local AI had no legal moves")
     }
 
-    @Test("Random Dan passes after rolling blocked bar entries")
+    @Test("Local AI passes after rolling blocked bar entries")
     @MainActor
-    func randomDanPassesAfterRollingBlockedBarEntries() async throws {
+    func localAIPassesAfterRollingBlockedBarEntries() async throws {
         var board = Board.empty()
         try board.setPoint(PointID(rawValue: 5)!, owner: .white, count: 2)
         try board.setPoint(PointID(rawValue: 6)!, owner: .white, count: 2)
@@ -267,12 +267,12 @@ struct MatchViewModelTests {
 
         #expect(passed)
         #expect(viewModel.lastError == nil)
-        #expect(viewModel.phaseTitle == "Random Dan had no legal moves")
+        #expect(viewModel.phaseTitle == "Local AI had no legal moves")
     }
 
-    @Test("Random Dan prefers the biggest pip reduction and breaks ties deterministically")
+    @Test("Local AI prefers the biggest pip reduction and breaks ties deterministically")
     @MainActor
-    func randomDanPipBiasedSelectionUsesDeterministicTieBreaking() throws {
+    func localAIPipBiasedSelectionUsesDeterministicTieBreaking() throws {
         let roll = try DiceRoll(die1: 6, die2: 1)
         let state = MatchState(
             config: .tournament(targetScore: 1),
@@ -282,7 +282,7 @@ struct MatchViewModelTests {
             )
         )
         let legalActions = MatchEngine.legalActions(in: state)
-        let opponent = RandomDanOpponent(randomIndex: { upperBound in upperBound - 1 })
+        let opponent = LocalAIOpponent(randomIndex: { upperBound in upperBound - 1 })
 
         let move = try #require(opponent.selectPipBiasedMove(
             for: .black,
@@ -296,9 +296,9 @@ struct MatchViewModelTests {
         #expect(move.destination == .point(PointID(rawValue: 23)!))
     }
 
-    @Test("Random Dan takes normal doubles and drops only clearly bad match-deciding doubles")
+    @Test("Local AI takes normal doubles and drops only clearly bad match-deciding doubles")
     @MainActor
-    func randomDanCubeResponsePolicy() {
+    func localAICubeResponsePolicy() {
         let state = MatchState(
             config: .tournament(targetScore: 1),
             game: GameState(
@@ -307,7 +307,7 @@ struct MatchViewModelTests {
             )
         )
         let legalActions = MatchEngine.legalActions(in: state)
-        let opponent = RandomDanOpponent(randomIndex: { _ in 0 })
+        let opponent = LocalAIOpponent(randomIndex: { _ in 0 })
 
         #expect(opponent.action(
             as: .black,
@@ -324,13 +324,13 @@ struct MatchViewModelTests {
         ) == .dropDouble(.black))
     }
 
-    @Test("Random Dan quick match can complete from automated legal play")
+    @Test("Local AI quick match can complete from automated legal play")
     @MainActor
-    func randomDanQuickMatchCompletesFromLegalPlay() async {
+    func localAIQuickMatchCompletesFromLegalPlay() async {
         let viewModel = MatchViewModel(
             engine: MatchEngine(diceRoller: CyclingDiceRoller()),
             config: .tournament(targetScore: 1),
-            opponentController: RandomDanOpponent(randomIndex: { _ in 0 }),
+            opponentController: LocalAIOpponent(randomIndex: { _ in 0 }),
             opponentDelay: {}
         )
 


### PR DESCRIPTION
Renames the local AI match opponent from Random Dan to Local AI across the match view model and tests. Updates AI rivalry creation to reuse and rename legacy Random Dan rivals so existing local AI history is preserved.\n\nTests: ./scripts/test.sh