### PR TITLE
Add turn undo and submit flow

### DIFF
--- a/SheshBesh.xcodeproj/xcshareddata/xcschemes/SheshBesh.xcscheme
+++ b/SheshBesh.xcodeproj/xcshareddata/xcschemes/SheshBesh.xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "AF1000000000000000000028"
-               BuildableName = "SheshBesh.app"
+               BuildableName = "Gammon With Friends.app"
                BlueprintName = "SheshBesh"
                ReferencedContainer = "container:SheshBesh.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "AF1000000000000000000028"
-            BuildableName = "SheshBesh.app"
+            BuildableName = "Gammon With Friends.app"
             BlueprintName = "SheshBesh"
             ReferencedContainer = "container:SheshBesh.xcodeproj">
          </BuildableReference>
@@ -80,7 +80,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "AF1000000000000000000028"
-            BuildableName = "SheshBesh.app"
+            BuildableName = "Gammon With Friends.app"
             BlueprintName = "SheshBesh"
             ReferencedContainer = "container:SheshBesh.xcodeproj">
          </BuildableReference>
@@ -97,7 +97,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "AF1000000000000000000028"
-            BuildableName = "SheshBesh.app"
+            BuildableName = "Gammon With Friends.app"
             BlueprintName = "SheshBesh"
             ReferencedContainer = "container:SheshBesh.xcodeproj">
          </BuildableReference>

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -1167,7 +1167,26 @@ private struct ActionBar: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            switch viewModel.state.game.phase {
+            if viewModel.isTurnDraftPending {
+                SecondaryActionButton(title: "Undo move") {
+                    viewModel.undoLastMove()
+                    onAction()
+                }
+
+                Text(draftStatusText)
+                    .font(LinenBrass.uiFont(size: 15, weight: .semibold))
+                    .foregroundStyle(LinenBrass.cream)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                    .frame(maxWidth: .infinity, minHeight: 48)
+
+                PrimaryActionButton(title: "Submit turn", isEnabled: viewModel.canSubmitTurn) {
+                    if viewModel.submitTurnIfAllowed() {
+                        onAction()
+                    }
+                }
+            } else {
+                switch viewModel.state.game.phase {
             case .awaitingOpeningRoll(let tiedRoll):
                 PrimaryActionButton(title: tiedRoll == nil ? "Opening roll" : "Reroll") {
                     viewModel.rollOpeningDice()
@@ -1263,6 +1282,7 @@ private struct ActionBar: View {
                     .frame(minHeight: 48)
                 }
             }
+            }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
@@ -1304,10 +1324,19 @@ private struct ActionBar: View {
             .accessibilityIdentifier("action-resign")
         }
     }
+
+    private var draftStatusText: String {
+        guard !viewModel.canSubmitTurn else { return "Ready" }
+        if case .awaitingMove(let turn) = viewModel.state.game.phase, turn.player == viewModel.localPlayer {
+            return "\(turn.remainingDice.count) move\(turn.remainingDice.count == 1 ? "" : "s") left"
+        }
+        return "Finish moves"
+    }
 }
 
 private struct PrimaryActionButton: View {
     let title: String
+    var isEnabled: Bool = true
     let action: () -> Void
 
     var body: some View {
@@ -1319,6 +1348,7 @@ private struct PrimaryActionButton: View {
                 .frame(maxWidth: .infinity, minHeight: 48)
         }
         .buttonStyle(LinenButtonStyle(kind: .primary))
+        .disabled(!isEnabled)
         .accessibilityIdentifier(actionAccessibilityIdentifier(for: title))
     }
 }

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -17,6 +17,7 @@ public final class MatchViewModel {
     public private(set) var pipCounts: [Player: Int]
     public private(set) var isOpponentThinking: Bool
     public private(set) var turnNotice: String?
+    private var turnDraftSnapshots: [MatchState]
 
     public let localPlayer: Player
     public let opponentName: String
@@ -55,6 +56,7 @@ public final class MatchViewModel {
         self.opponentDelay = opponentDelay
         self.isOpponentThinking = false
         self.turnNotice = nil
+        self.turnDraftSnapshots = []
         self.legalActions = initialLegalActions
         self.legalMoves = initialLegalActions.compactMap { action in
             if case .move(let move) = action {
@@ -87,11 +89,11 @@ public final class MatchViewModel {
     }
 
     public var isLocalTurn: Bool {
-        activePlayer == localPlayer
+        isTurnDraftPending || activePlayer == localPlayer
     }
 
     public var isOpponentTurn: Bool {
-        activePlayer == localPlayer.opponent
+        !isTurnDraftPending && activePlayer == localPlayer.opponent
     }
 
     public var currentCubeOffer: CubeOffer? {
@@ -110,6 +112,7 @@ public final class MatchViewModel {
 
     public var isOpponentAutomationActive: Bool {
         guard isOpponentAutoplayEnabled else { return false }
+        guard !isTurnDraftPending else { return false }
         return opponentController.canAct(
             as: localPlayer.opponent,
             in: state,
@@ -119,6 +122,7 @@ public final class MatchViewModel {
 
     public var interactiveLegalMoves: [Move] {
         guard !isOpponentAutomationActive else { return [] }
+        guard activePlayer == localPlayer else { return [] }
         return legalMoves
     }
 
@@ -130,9 +134,36 @@ public final class MatchViewModel {
         state.score.score(for: localPlayer.opponent)
     }
 
+    public var isTurnDraftPending: Bool {
+        !turnDraftSnapshots.isEmpty
+    }
+
+    public var canUndoTurnMove: Bool {
+        isTurnDraftPending
+    }
+
+    public var canSubmitTurn: Bool {
+        guard isTurnDraftPending else { return false }
+
+        if state.completion != nil {
+            return true
+        }
+
+        switch state.game.phase {
+        case .awaitingMove(let turn) where turn.player == localPlayer:
+            return MoveValidator.legalFirstMoves(for: localPlayer, in: state.game).isEmpty
+        default:
+            return activePlayer != localPlayer
+        }
+    }
+
     public var phaseTitle: String {
         if let completion = state.completion {
             return completion.winner == localPlayer ? "You won the match" : "\(opponentName) won the match"
+        }
+
+        if isTurnDraftPending, canSubmitTurn {
+            return "Ready to submit"
         }
 
         if isOpponentAutomationActive {
@@ -169,6 +200,11 @@ public final class MatchViewModel {
     }
 
     public func send(_ action: MatchAction) {
+        if case .move(let move) = action, shouldDraft(move) {
+            applyDraft(move)
+            return
+        }
+
         apply(action, schedulesOpponent: true)
     }
 
@@ -177,6 +213,7 @@ public final class MatchViewModel {
             let hadCompletion = state.completion != nil
             state = try engine.apply(action: action, to: state)
             lastError = nil
+            turnDraftSnapshots.removeAll()
             refreshDerivedState()
             notifyStorageCallbacks(hadCompletion: hadCompletion)
             if schedulesOpponent {
@@ -225,6 +262,7 @@ public final class MatchViewModel {
     public func restartMatch() {
         state = MatchEngine.newMatch(config: state.config)
         lastError = nil
+        turnDraftSnapshots.removeAll()
         didNotifyCompletion = false
         refreshDerivedState()
         onStateChange?(state)
@@ -239,8 +277,38 @@ public final class MatchViewModel {
         guard let move = legalMoves.first(where: { $0.source == source && $0.destination == destination }) else {
             return false
         }
-        send(.move(move))
+        applyDraft(move)
         return lastError == nil
+    }
+
+    public func undoLastMove() {
+        guard let previousState = turnDraftSnapshots.popLast() else { return }
+        state = previousState
+        lastError = nil
+        turnNotice = nil
+        refreshDerivedState()
+    }
+
+    @discardableResult
+    public func submitTurnIfAllowed() -> Bool {
+        guard isTurnDraftPending else {
+            lastError = "Make a move before submitting."
+            return false
+        }
+
+        guard canSubmitTurn else {
+            lastError = "Finish all legal moves before submitting."
+            return false
+        }
+
+        let hadCompletion = turnDraftSnapshots.first?.completion != nil
+        turnDraftSnapshots.removeAll()
+        lastError = nil
+        refreshDerivedState()
+        notifyStorageCallbacks(hadCompletion: hadCompletion)
+        turnNotice = nil
+        scheduleOpponentTurnIfNeeded()
+        return true
     }
 
     public func legalDestinations(from source: MoveSource) -> [MoveDestination] {
@@ -270,6 +338,33 @@ public final class MatchViewModel {
             }
         }
         pipCounts = Self.computePipCounts(for: state.game.board)
+    }
+
+    private func shouldDraft(_ move: Move) -> Bool {
+        guard move.player == localPlayer else { return false }
+        guard !isOpponentAutomationActive else { return false }
+        guard case .awaitingMove(let turn) = state.game.phase, turn.player == localPlayer else {
+            return false
+        }
+        return true
+    }
+
+    private func applyDraft(_ move: Move) {
+        guard shouldDraft(move) else {
+            apply(.move(move), schedulesOpponent: true)
+            return
+        }
+
+        turnDraftSnapshots.append(state)
+        do {
+            state = try engine.apply(action: .move(move), to: state)
+            lastError = nil
+            turnNotice = nil
+            refreshDerivedState()
+        } catch {
+            _ = turnDraftSnapshots.popLast()
+            lastError = friendlyErrorMessage(error)
+        }
     }
 
     private func scheduleOpponentTurnIfNeeded() {

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -296,11 +296,14 @@ public final class MatchViewModel {
             return false
         }
 
-        let hadCompletion = turnDraftSnapshots.first?.completion != nil
         turnDraftSnapshots.removeAll()
         lastError = nil
         refreshDerivedState()
-        notifyStorageCallbacks(hadCompletion: hadCompletion)
+        if state.completion != nil {
+            notifyCompletionIfNeeded()
+        } else {
+            onStateChange?(state)
+        }
         turnNotice = nil
         scheduleOpponentTurnIfNeeded()
         return true
@@ -419,12 +422,17 @@ public final class MatchViewModel {
     }
 
     private func notifyStorageCallbacks(hadCompletion: Bool) {
-        if !hadCompletion, state.completion != nil, !didNotifyCompletion {
-            didNotifyCompletion = true
-            onCompletion?(state)
+        if !hadCompletion, state.completion != nil {
+            notifyCompletionIfNeeded()
         } else if state.completion == nil {
             onStateChange?(state)
         }
+    }
+
+    private func notifyCompletionIfNeeded() {
+        guard !didNotifyCompletion else { return }
+        didNotifyCompletion = true
+        onCompletion?(state)
     }
 
     private func friendlyErrorMessage(_ error: Error) -> String {

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -299,11 +299,7 @@ public final class MatchViewModel {
         turnDraftSnapshots.removeAll()
         lastError = nil
         refreshDerivedState()
-        if state.completion != nil {
-            notifyCompletionIfNeeded()
-        } else {
-            onStateChange?(state)
-        }
+        notifyStorageCallbacks(hadCompletion: false)
         turnNotice = nil
         scheduleOpponentTurnIfNeeded()
         return true

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -149,12 +149,7 @@ public final class MatchViewModel {
             return true
         }
 
-        switch state.game.phase {
-        case .awaitingMove(let turn) where turn.player == localPlayer:
-            return MoveValidator.legalFirstMoves(for: localPlayer, in: state.game).isEmpty
-        default:
-            return activePlayer != localPlayer
-        }
+        return activePlayer != localPlayer
     }
 
     public var phaseTitle: String {

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -68,9 +68,146 @@ struct MatchViewModelTests {
         )
 
         #expect(moved)
+        #expect(viewModel.isTurnDraftPending)
         #expect(viewModel.state.game.board.point(PointID(rawValue: 24)!).count == 1)
         #expect(viewModel.state.game.board.point(PointID(rawValue: 18)!).owner == .white)
         #expect(viewModel.state.game.board.point(PointID(rawValue: 18)!).count == 1)
+    }
+
+    @Test("drafted checker moves do not notify storage before submit")
+    @MainActor
+    func draftedCheckerMovesDoNotNotifyBeforeSubmit() {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            config: .tournament(targetScore: 7),
+            isOpponentAutoplayEnabled: false
+        )
+
+        viewModel.rollOpeningDice()
+
+        var stateChangeCount = 0
+        viewModel.onStateChange = { _ in
+            stateChangeCount += 1
+        }
+
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 18)!)))
+
+        #expect(viewModel.isTurnDraftPending)
+        #expect(stateChangeCount == 0)
+        #expect(viewModel.state.game.board.point(PointID(rawValue: 24)!).count == 1)
+    }
+
+    @Test("undo restores the previous drafted move state")
+    @MainActor
+    func undoRestoresPreviousDraftState() {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            config: .tournament(targetScore: 7),
+            isOpponentAutoplayEnabled: false
+        )
+
+        viewModel.rollOpeningDice()
+        let rolledState = viewModel.state
+
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 18)!)))
+        viewModel.undoLastMove()
+
+        #expect(viewModel.state == rolledState)
+        #expect(!viewModel.isTurnDraftPending)
+        #expect(!viewModel.canUndoTurnMove)
+        #expect(viewModel.lastError == nil)
+    }
+
+    @Test("submit commits a completed local turn once")
+    @MainActor
+    func submitCommitsCompletedLocalTurnOnce() {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            config: .tournament(targetScore: 7),
+            isOpponentAutoplayEnabled: false
+        )
+
+        viewModel.rollOpeningDice()
+
+        var stateChangeCount = 0
+        viewModel.onStateChange = { _ in
+            stateChangeCount += 1
+        }
+
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 18)!)))
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 23)!)))
+        #expect(viewModel.canSubmitTurn)
+
+        #expect(viewModel.submitTurnIfAllowed())
+
+        #expect(stateChangeCount == 1)
+        #expect(!viewModel.isTurnDraftPending)
+        guard case .awaitingRoll(.black) = viewModel.state.game.phase else {
+            Issue.record("Expected submitted turn to pass to black's roll.")
+            return
+        }
+    }
+
+    @Test("submit is rejected while local legal moves remain")
+    @MainActor
+    func submitIsRejectedWhileMovesRemain() {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            config: .tournament(targetScore: 7),
+            isOpponentAutoplayEnabled: false
+        )
+
+        viewModel.rollOpeningDice()
+        var stateChangeCount = 0
+        viewModel.onStateChange = { _ in
+            stateChangeCount += 1
+        }
+
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 18)!)))
+        #expect(!viewModel.submitTurnIfAllowed())
+
+        #expect(viewModel.isTurnDraftPending)
+        #expect(stateChangeCount == 0)
+        #expect(viewModel.lastError == "Finish all legal moves before submitting.")
+    }
+
+    @Test("game ending checker move completes only after submit and can be undone")
+    @MainActor
+    func gameEndingMoveCompletesOnlyAfterSubmitAndCanBeUndone() throws {
+        var board = Board.empty()
+        try board.setPoint(PointID(rawValue: 1)!, owner: .white, count: 1)
+        try board.setPoint(PointID(rawValue: 24)!, owner: .black, count: 15)
+        try board.setBorneOff(for: .white, count: 14)
+
+        let roll = try DiceRoll(die1: 1, die2: 1)
+        let state = MatchState(
+            config: .tournament(targetScore: 1),
+            game: GameState(
+                board: board,
+                phase: .awaitingMove(TurnState(player: .white, roll: roll, remainingDice: [1]))
+            )
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            initialState: state,
+            isOpponentAutoplayEnabled: false
+        )
+        var completionCount = 0
+        viewModel.onCompletion = { _ in
+            completionCount += 1
+        }
+
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 1)!), to: .off))
+        #expect(viewModel.state.completion?.winner == .white)
+        #expect(completionCount == 0)
+
+        viewModel.undoLastMove()
+        #expect(viewModel.state.completion == nil)
+        #expect(!viewModel.isTurnDraftPending)
+
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 1)!), to: .off))
+        #expect(viewModel.submitTurnIfAllowed())
+        #expect(completionCount == 1)
     }
 
     @Test("offering resignation enters resignation response phase")
@@ -186,6 +323,7 @@ struct MatchViewModelTests {
         viewModel.rollOpeningDice()
         #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 18)!)))
         #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 23)!)))
+        #expect(viewModel.submitTurnIfAllowed())
 
         let returnedToWhite = await waitUntil {
             if case .awaitingRoll(.white) = viewModel.state.game.phase {
@@ -196,6 +334,44 @@ struct MatchViewModelTests {
 
         #expect(returnedToWhite)
         #expect(viewModel.lastError == nil)
+        #expect(viewModel.pipCount(for: .black) < 167)
+    }
+
+    @Test("Random Dan waits for local drafted turn submission")
+    @MainActor
+    func randomDanWaitsForDraftSubmit() async {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 3, 2])),
+            config: .tournament(targetScore: 1),
+            opponentController: RandomDanOpponent(randomIndex: { _ in 0 }),
+            opponentDelay: {}
+        )
+
+        viewModel.rollOpeningDice()
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 18)!)))
+        #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 23)!)))
+
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+
+        #expect(viewModel.isTurnDraftPending)
+        #expect(viewModel.pipCount(for: .black) == 167)
+        guard case .awaitingRoll(.black) = viewModel.state.game.phase else {
+            Issue.record("Expected drafted local turn to wait at black's roll before submission.")
+            return
+        }
+
+        #expect(viewModel.submitTurnIfAllowed())
+
+        let returnedToWhite = await waitUntil {
+            if case .awaitingRoll(.white) = viewModel.state.game.phase {
+                return true
+            }
+            return false
+        }
+
+        #expect(returnedToWhite)
         #expect(viewModel.pipCount(for: .black) < 167)
     }
 
@@ -337,7 +513,10 @@ struct MatchViewModelTests {
         var actionCount = 0
         while viewModel.state.completion == nil, actionCount < 1_000 {
             actionCount += 1
-            switch viewModel.state.game.phase {
+            if viewModel.isTurnDraftPending, viewModel.canSubmitTurn {
+                viewModel.submitTurnIfAllowed()
+            } else {
+                switch viewModel.state.game.phase {
             case .awaitingOpeningRoll:
                 viewModel.rollOpeningDice()
             case .awaitingRoll(.white):
@@ -354,6 +533,7 @@ struct MatchViewModelTests {
                 viewModel.send(.rejectResignation(.white))
             default:
                 await Task.yield()
+                }
             }
 
             #expect(viewModel.lastError == nil)
@@ -396,6 +576,7 @@ private func advanceToOpponentRoll(_ viewModel: MatchViewModel) {
         from: .point(PointID(rawValue: 24)!),
         to: .point(PointID(rawValue: 23)!)
     )
+    _ = viewModel.submitTurnIfAllowed()
 }
 
 private final class ScriptedDiceRoller: DiceRolling, @unchecked Sendable {

--- a/SheshBeshUITests/SheshBeshUITests.swift
+++ b/SheshBeshUITests/SheshBeshUITests.swift
@@ -37,6 +37,8 @@ final class SheshBeshUITests: XCTestCase {
 
         element("point-24", in: app).tap()
         element("point-23", in: app).tap()
+        XCTAssertTrue(app.buttons["action-submit-turn"].exists)
+        app.buttons["action-submit-turn"].tap()
         XCTAssertTrue(app.buttons["action-roll-dice"].waitForExistence(timeout: 4))
         XCTAssertEqual(app.staticTexts["header-phase-title"].label, "Your turn")
     }
@@ -57,6 +59,7 @@ final class SheshBeshUITests: XCTestCase {
         element("point-18", in: app).tap()
         element("point-24", in: app).tap()
         element("point-23", in: app).tap()
+        app.buttons["action-submit-turn"].tap()
 
         XCTAssertTrue(app.buttons["action-roll-dice"].waitForExistence(timeout: 4))
         attachScreenshot(named: "03-your-turn")


### PR DESCRIPTION
Adds in-memory checker-move drafts so local turns can be undone and explicitly submitted before storage, Game Center handoff, or Random Dan automation runs. Updates the SwiftUI action bar with Undo move and Submit turn controls, including disabled submit state while legal moves remain. Updates view-model and UI tests for deferred turn submission, undo, game-ending drafts, and opponent automation waiting for submit. Validation: swift test passed; ./scripts/test.sh passed package build/tests but the Xcode build step is blocked locally by a missing eligible iOS Simulator/iOS 26.4 platform.