### PR TITLE
Drop Random Dan legacy rival migration

### DIFF
--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -10,7 +10,6 @@ import SheshBeshLedger
 @Observable
 public final class LedgerCoordinator {
     private static let quickAIRivalDisplayName = "Local AI"
-    private static let legacyQuickAIRivalDisplayName = "Random Dan"
     private static let quickAIMatchConfig = MatchConfig.tournament(targetScore: 1)
 
     @ObservationIgnored private let store: any LedgerStore
@@ -97,15 +96,7 @@ public final class LedgerCoordinator {
         if let existingRival = ledgers
             .map(\.rival)
             .first(where: Self.isQuickAIRival) {
-            if existingRival.displayName == Self.quickAIRivalDisplayName {
-                rival = existingRival
-            } else {
-                var renamedRival = existingRival
-                renamedRival.displayName = Self.quickAIRivalDisplayName
-                try await store.upsertRival(renamedRival)
-                await refresh()
-                rival = renamedRival
-            }
+            rival = existingRival
         } else {
             rival = Rival(displayName: Self.quickAIRivalDisplayName)
             try await store.upsertRival(rival)
@@ -153,8 +144,7 @@ public final class LedgerCoordinator {
     }
 
     private static func isQuickAIRival(_ rival: Rival) -> Bool {
-        rival.gameCenterPlayerID == nil &&
-            (rival.displayName == quickAIRivalDisplayName || rival.displayName == legacyQuickAIRivalDisplayName)
+        rival.gameCenterPlayerID == nil && rival.displayName == quickAIRivalDisplayName
     }
 
     private static func sortLedgers(_ lhs: RivalLedger, _ rhs: RivalLedger) -> Bool {

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -138,21 +138,6 @@ struct LedgerCoordinatorTests {
         #expect(firstMatch.state.config.targetScore == 1)
     }
 
-    @Test("AI rivalry renames legacy Random Dan rival to Local AI")
-    @MainActor
-    func aiRivalryRenamesLegacyRandomDanRival() async throws {
-        let legacyRival = Rival(displayName: "Random Dan")
-        let store = InMemoryLedgerStore(rivals: [legacyRival])
-        let coordinator = LedgerCoordinator(store: store)
-
-        let match = try await coordinator.startAIRivalry()
-        let rivals = try await store.loadRivals()
-
-        #expect(rivals.count == 1)
-        #expect(rivals.first?.id == legacyRival.id)
-        #expect(rivals.first?.displayName == "Local AI")
-        #expect(match.rivalID == legacyRival.id)
-    }
 }
 
 private final class CompletionDiceRoller: DiceRolling, @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Remove the `legacyQuickAIRivalDisplayName` constant and the disjunct in `isQuickAIRival` that recognized old "Random Dan" rivals as the quick-AI opponent
- Collapse the now-dead rename branch in `startAIRivalry` and delete the test that exercised the migration

We're pre-alpha, so the one-shot rename added in #26 is no longer worth carrying.

## Test plan
- [x] `swift test --filter SheshBeshAppTests` (24 passing)