### PR TITLE
Simplify Game Center stack against Apple's turn-based sample

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -119,13 +119,18 @@ public struct BoardView: View {
 public struct OpponentTurnView: View {
     public let viewModel: MatchViewModel
     private let onBackToRivals: (() -> Void)?
+    private let onSendReminder: (@MainActor () async -> Void)?
+
+    @State private var isSendingReminder = false
 
     public init(
         viewModel: MatchViewModel,
-        onBackToRivals: (() -> Void)? = nil
+        onBackToRivals: (() -> Void)? = nil,
+        onSendReminder: (@MainActor () async -> Void)? = nil
     ) {
         self.viewModel = viewModel
         self.onBackToRivals = onBackToRivals
+        self.onSendReminder = onSendReminder
     }
 
     public var body: some View {
@@ -155,6 +160,10 @@ public struct OpponentTurnView: View {
                 .minimumScaleFactor(0.76)
 
             Spacer(minLength: 0)
+
+            if let onSendReminder {
+                reminderButton(action: onSendReminder)
+            }
         }
         .padding(.horizontal, 14)
         .frame(minHeight: 42)
@@ -165,6 +174,25 @@ public struct OpponentTurnView: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("opponent-turn-status")
+    }
+
+    private func reminderButton(action: @escaping @MainActor () async -> Void) -> some View {
+        Button {
+            isSendingReminder = true
+            Task {
+                await action()
+                isSendingReminder = false
+            }
+        } label: {
+            Label("Remind", systemImage: "bell.badge")
+                .font(LinenBrass.uiFont(size: 13, weight: .semibold))
+                .labelStyle(.titleAndIcon)
+        }
+        .buttonStyle(.bordered)
+        .tint(LinenBrass.brass)
+        .foregroundStyle(LinenBrass.cream)
+        .disabled(isSendingReminder)
+        .accessibilityIdentifier("opponent-turn-remind")
     }
 
     private var statusText: String {

--- a/SheshBesh/Shared/GameCenterEnvelope.swift
+++ b/SheshBesh/Shared/GameCenterEnvelope.swift
@@ -95,7 +95,7 @@ public struct GameCenterMatchEnvelope: Codable, Equatable, Hashable, Sendable {
     }
 
     public static func decoded(from data: Data) throws -> GameCenterMatchEnvelope {
-        let envelope = try JSONDecoder.gameCenterEnvelope.decode(GameCenterMatchEnvelope.self, from: data)
+        let envelope = try JSONDecoder().decode(GameCenterMatchEnvelope.self, from: data)
         try envelope.validateSupported()
         return envelope
     }
@@ -163,11 +163,5 @@ private extension JSONEncoder {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         return encoder
-    }
-}
-
-private extension JSONDecoder {
-    static var gameCenterEnvelope: JSONDecoder {
-        JSONDecoder()
     }
 }

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -23,7 +23,7 @@ public enum GameCenterAuthState: Equatable, Sendable {
 
 @MainActor
 @Observable
-public final class GameCenterSession: NSObject, GKLocalPlayerListener {
+public final class GameCenterSession: NSObject, @preconcurrency GKLocalPlayerListener {
     public private(set) var authState: GameCenterAuthState = .notStarted
     public private(set) var localPlayerID: String?
     public private(set) var localDisplayName: String?
@@ -33,6 +33,7 @@ public final class GameCenterSession: NSObject, GKLocalPlayerListener {
 
     @ObservationIgnored public var onTurnEvent: (@MainActor (GKTurnBasedMatch, Bool) -> Void)?
     @ObservationIgnored public var onMatchEnded: (@MainActor (GKTurnBasedMatch) -> Void)?
+    @ObservationIgnored public var onWantsToQuitMatch: (@MainActor (GKTurnBasedMatch) -> Void)?
 
     public func authenticate() {
         let attemptID = UUID()
@@ -108,44 +109,24 @@ public final class GameCenterSession: NSObject, GKLocalPlayerListener {
         }
     }
 
-    public func loadMatches() async throws -> [GameCenterTurnBasedMatchBox] {
-        try await withCheckedThrowingContinuation { continuation in
-            GKTurnBasedMatch.loadMatches { matches, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: (matches ?? []).map(GameCenterTurnBasedMatchBox.init(match:)))
-                }
-            }
-        }
+    public func loadMatches() async throws -> [GKTurnBasedMatch] {
+        try await GKTurnBasedMatch.loadMatches() ?? []
     }
 
-    nonisolated public func player(
+    public func player(
         _ player: GKPlayer,
         receivedTurnEventFor match: GKTurnBasedMatch,
         didBecomeActive: Bool
     ) {
-        let matchBox = GameCenterTurnBasedMatchBox(match: match)
-        DispatchQueue.main.async { [weak self] in
-            self?.onTurnEvent?(matchBox.match, didBecomeActive)
-        }
+        onTurnEvent?(match, didBecomeActive)
     }
 
-    nonisolated public func player(_ player: GKPlayer, matchEnded match: GKTurnBasedMatch) {
-        let matchBox = GameCenterTurnBasedMatchBox(match: match)
-        DispatchQueue.main.async { [weak self] in
-            self?.onMatchEnded?(matchBox.match)
-        }
+    public func player(_ player: GKPlayer, matchEnded match: GKTurnBasedMatch) {
+        onMatchEnded?(match)
     }
-}
 
-public final class GameCenterTurnBasedMatchBox: @unchecked Sendable, Identifiable {
-    public let id: String
-    public let match: GKTurnBasedMatch
-
-    public init(match: GKTurnBasedMatch) {
-        self.id = match.matchID
-        self.match = match
+    public func player(_ player: GKPlayer, wantsToQuitMatch match: GKTurnBasedMatch) {
+        onWantsToQuitMatch?(match)
     }
 }
 
@@ -197,7 +178,7 @@ public final class GameCenterMatchCoordinator {
 
     public func load(match: GKTurnBasedMatch, targetScore: Int = 7) async throws -> GameCenterLoadedMatch {
         let localPlayerID = GKLocalPlayer.local.gamePlayerID
-        let data = try await match.loadGameData()
+        let data = try await match.loadMatchData()
         let envelope: GameCenterMatchEnvelope
 
         if let data, !data.isEmpty {
@@ -226,7 +207,9 @@ public final class GameCenterMatchCoordinator {
     }
 
     public func commit(state: MatchState, for loaded: GameCenterLoadedMatch) async throws -> GameCenterLoadedMatch {
-        guard loaded.match.currentParticipant?.player?.gamePlayerID == loaded.localPlayerID else {
+        let match = try await GKTurnBasedMatch.load(withID: loaded.match.matchID)
+
+        guard match.currentParticipant?.player?.gamePlayerID == loaded.localPlayerID else {
             throw GameCenterCoordinatorError.notLocalPlayersTurn
         }
 
@@ -236,22 +219,30 @@ public final class GameCenterMatchCoordinator {
         envelope.state = state
         envelope.config = state.config
 
-        let data = try validatedData(for: envelope, maximumSize: loaded.match.matchDataMaximumSize)
+        let data = try validatedData(for: envelope, maximumSize: match.matchDataMaximumSize)
 
         if state.completion != nil {
-            try await endMatch(loaded.match, envelope: envelope, data: data)
+            try await endMatch(match, envelope: envelope, data: data)
         } else if let activePlayer = activePlayer(in: state),
                   activePlayer != loaded.localPlayer {
             envelope.turnCounter += 1
-            let turnData = try validatedData(for: envelope, maximumSize: loaded.match.matchDataMaximumSize)
-            let nextParticipant = try participant(for: activePlayer, in: loaded.match, envelope: envelope)
-            try await loaded.match.endTurn(to: nextParticipant, data: turnData)
+            let turnData = try validatedData(for: envelope, maximumSize: match.matchDataMaximumSize)
+            let nextParticipant = try participant(for: activePlayer, in: match, envelope: envelope)
+            match.setLocalizableMessageWithKey(
+                "%@ played a turn in Shesh Besh.",
+                arguments: [GKLocalPlayer.local.displayName]
+            )
+            try await match.endTurn(
+                withNextParticipants: [nextParticipant],
+                turnTimeout: GKTurnTimeoutDefault,
+                match: turnData
+            )
         } else {
-            try await loaded.match.saveCurrentTurnData(data)
+            try await match.saveCurrentTurn(withMatch: data)
         }
 
         let updated = try await reconcileLedger(
-            for: loaded.match,
+            for: match,
             envelope: envelope,
             localPlayerID: loaded.localPlayerID
         )
@@ -264,8 +255,28 @@ public final class GameCenterMatchCoordinator {
     }
 
     public func sendReminder(for loaded: GameCenterLoadedMatch) async throws {
-        let nextParticipant = try participant(for: loaded.opponentPlayer, in: loaded.match, envelope: loaded.envelope)
-        try await loaded.match.sendGameCenterReminder(to: nextParticipant)
+        let match = try await GKTurnBasedMatch.load(withID: loaded.match.matchID)
+        let nextParticipant = try participant(for: loaded.opponentPlayer, in: match, envelope: loaded.envelope)
+        try await match.sendReminder(
+            to: [nextParticipant],
+            localizableMessageKey: "Your move in Shesh Besh.",
+            arguments: []
+        )
+    }
+
+    public func quit(loaded: GameCenterLoadedMatch) async throws {
+        let match = try await GKTurnBasedMatch.load(withID: loaded.match.matchID)
+        if match.currentParticipant?.player?.gamePlayerID == loaded.localPlayerID {
+            let nextParticipants = match.participants.filter { $0 != match.currentParticipant }
+            try await match.participantQuitInTurn(
+                with: .quit,
+                nextParticipants: nextParticipants,
+                turnTimeout: GKTurnTimeoutDefault,
+                match: match.matchData ?? Data()
+            )
+        } else {
+            try await match.participantQuitOutOfTurn(with: .quit)
+        }
     }
 
     private func reconcileLedger(
@@ -311,7 +322,7 @@ public final class GameCenterMatchCoordinator {
 
     private func save(envelope: GameCenterMatchEnvelope, to match: GKTurnBasedMatch) async throws {
         let data = try validatedData(for: envelope, maximumSize: match.matchDataMaximumSize)
-        try await match.saveCurrentTurnData(data)
+        try await match.saveCurrentTurn(withMatch: data)
     }
 
     private func endMatch(
@@ -326,7 +337,7 @@ public final class GameCenterMatchCoordinator {
             participant.matchOutcome = participant.player?.gamePlayerID == winnerID ? .won : .lost
         }
 
-        try await match.endMatch(data: data)
+        try await match.endMatchInTurn(withMatch: data)
     }
 
     private func validatedData(for envelope: GameCenterMatchEnvelope, maximumSize: Int) throws -> Data {
@@ -684,15 +695,7 @@ public struct GameCenterHomeView: View {
         defer { isLoadingMatches = false }
 
         do {
-            let matchBoxes = try await session.loadMatches()
-            var gameCenterMatches: [GKTurnBasedMatch] = []
-            for box in matchBoxes {
-                let match = box.match
-                let status = match.status
-                if status == .open || status == .matching || status == .ended {
-                    gameCenterMatches.append(match)
-                }
-            }
+            let gameCenterMatches = try await session.loadMatches()
             var loaded: [GameCenterLoadedMatch] = []
             for match in gameCenterMatches {
                 loaded.append(try await matchCoordinator.load(match: match, targetScore: selectedTargetScore))
@@ -824,79 +827,5 @@ private struct EmptyGameCenterLedgerView: View {
 private struct AuthenticationController: Identifiable {
     let id = UUID()
     let viewController: UIViewController
-}
-
-@MainActor
-private extension GKTurnBasedMatch {
-    func loadGameData() async throws -> Data? {
-        try await withCheckedThrowingContinuation { continuation in
-            loadMatchData { data, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume(returning: data)
-                }
-            }
-        }
-    }
-
-    func saveCurrentTurnData(_ data: Data) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-            saveCurrentTurn(withMatch: data) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
-    }
-
-    func endTurn(to participant: GKTurnBasedParticipant, data: Data) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-            endTurn(
-                withNextParticipants: [participant],
-                turnTimeout: GKTurnTimeoutDefault,
-                match: data
-            ) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
-    }
-
-    func endMatch(data: Data) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-            endMatchInTurn(withMatch: data) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
-    }
-}
-
-private extension GKTurnBasedMatch {
-    @MainActor
-    func sendGameCenterReminder(to participant: GKTurnBasedParticipant) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-            sendReminder(
-                to: [participant],
-                localizableMessageKey: "Your move in Shesh Besh.",
-                arguments: []
-            ) { error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else {
-                    continuation.resume()
-                }
-            }
-        }
-    }
 }
 #endif

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -18,22 +18,34 @@ public struct RootView: View {
     @State private var routeError: String?
     #if canImport(GameKit) && canImport(UIKit)
     @State private var gameCenterSession = GameCenterSession()
+    @State private var gameCenterMatchCoordinator: GameCenterMatchCoordinator
     @State private var activeGameCenterMatch: GameCenterLoadedMatch?
     #endif
 
     public init() {
+        let ledger = LedgerCoordinator(store: InMemoryLedgerStore())
         _singleMatchViewModel = State(initialValue: nil)
-        _coordinator = State(initialValue: LedgerCoordinator(store: InMemoryLedgerStore()))
+        _coordinator = State(initialValue: ledger)
+        #if canImport(GameKit) && canImport(UIKit)
+        _gameCenterMatchCoordinator = State(initialValue: GameCenterMatchCoordinator(ledgerCoordinator: ledger))
+        #endif
     }
 
     public init(coordinator: LedgerCoordinator) {
         _singleMatchViewModel = State(initialValue: nil)
         _coordinator = State(initialValue: coordinator)
+        #if canImport(GameKit) && canImport(UIKit)
+        _gameCenterMatchCoordinator = State(initialValue: GameCenterMatchCoordinator(ledgerCoordinator: coordinator))
+        #endif
     }
 
     public init(viewModel: MatchViewModel) {
+        let ledger = LedgerCoordinator(store: InMemoryLedgerStore())
         _singleMatchViewModel = State(initialValue: viewModel)
-        _coordinator = State(initialValue: LedgerCoordinator(store: InMemoryLedgerStore()))
+        _coordinator = State(initialValue: ledger)
+        #if canImport(GameKit) && canImport(UIKit)
+        _gameCenterMatchCoordinator = State(initialValue: GameCenterMatchCoordinator(ledgerCoordinator: ledger))
+        #endif
     }
 
     public var body: some View {
@@ -41,9 +53,11 @@ public struct RootView: View {
             if let singleMatchViewModel {
                 matchView(for: singleMatchViewModel)
             } else if let activeMatchViewModel {
-                matchView(for: activeMatchViewModel) {
-                    self.activeMatchViewModel = nil
-                }
+                matchView(
+                    for: activeMatchViewModel,
+                    onBackToRivals: { self.activeMatchViewModel = nil },
+                    onSendReminder: reminderActionForActiveMatch
+                )
                     .sheet(item: $completedRecord) { record in
                         MatchEndSheet(
                             record: record,
@@ -59,7 +73,7 @@ public struct RootView: View {
                 GameCenterHomeView(
                     session: gameCenterSession,
                     ledgerCoordinator: coordinator,
-                    matchCoordinator: GameCenterMatchCoordinator(ledgerCoordinator: coordinator),
+                    matchCoordinator: gameCenterMatchCoordinator,
                     onOpenLocalMatch: openMatch,
                     onOpenMatch: openGameCenterMatch
                 )
@@ -90,15 +104,28 @@ public struct RootView: View {
         }
     }
 
+    private var reminderActionForActiveMatch: (@MainActor () async -> Void)? {
+        #if canImport(GameKit) && canImport(UIKit)
+        return gameCenterReminderAction()
+        #else
+        return nil
+        #endif
+    }
+
     @ViewBuilder
     private func matchView(
         for viewModel: MatchViewModel,
-        onBackToRivals: (() -> Void)? = nil
+        onBackToRivals: (() -> Void)? = nil,
+        onSendReminder: (@MainActor () async -> Void)? = nil
     ) -> some View {
         if viewModel.doubleOfferForLocalPlayer != nil {
             DoubleOfferSheet(viewModel: viewModel, onBackToRivals: onBackToRivals)
         } else if viewModel.isOpponentTurn {
-            OpponentTurnView(viewModel: viewModel, onBackToRivals: onBackToRivals)
+            OpponentTurnView(
+                viewModel: viewModel,
+                onBackToRivals: onBackToRivals,
+                onSendReminder: onSendReminder
+            )
         } else {
             BoardView(viewModel: viewModel, onBackToRivals: onBackToRivals)
         }
@@ -162,24 +189,51 @@ public struct RootView: View {
     #if canImport(GameKit) && canImport(UIKit)
     private func configureGameCenterCallbacks() {
         gameCenterSession.onTurnEvent = { match, _ in
-            Task {
-                await loadAndOpenGameCenterMatch(match)
-            }
+            Task { await loadAndOpenGameCenterMatch(match) }
         }
         gameCenterSession.onMatchEnded = { match in
-            Task {
-                await loadAndOpenGameCenterMatch(match)
-            }
+            Task { await loadAndOpenGameCenterMatch(match) }
+        }
+        gameCenterSession.onWantsToQuitMatch = { match in
+            Task { await handleWantsToQuit(match) }
         }
     }
 
     private func loadAndOpenGameCenterMatch(_ match: GKTurnBasedMatch) async {
         do {
-            let loaded = try await GameCenterMatchCoordinator(ledgerCoordinator: coordinator)
-                .load(match: match)
+            let loaded = try await gameCenterMatchCoordinator.load(match: match)
             openGameCenterMatch(loaded)
         } catch {
             routeError = error.localizedDescription
+        }
+    }
+
+    private func handleWantsToQuit(_ match: GKTurnBasedMatch) async {
+        let loaded: GameCenterLoadedMatch
+        do {
+            loaded = try await gameCenterMatchCoordinator.load(match: match)
+            try await gameCenterMatchCoordinator.quit(loaded: loaded)
+        } catch {
+            routeError = error.localizedDescription
+            return
+        }
+
+        if activeGameCenterMatch?.match.matchID == match.matchID {
+            activeMatchViewModel = nil
+            activeGameCenterMatch = nil
+        }
+        await coordinator.refresh()
+    }
+
+    private func gameCenterReminderAction() -> (@MainActor () async -> Void)? {
+        guard activeGameCenterMatch != nil else { return nil }
+        return { [gameCenterMatchCoordinator] in
+            guard let current = activeGameCenterMatch else { return }
+            do {
+                try await gameCenterMatchCoordinator.sendReminder(for: current)
+            } catch {
+                routeError = error.localizedDescription
+            }
         }
     }
 
@@ -202,12 +256,11 @@ public struct RootView: View {
             isOpponentAutoplayEnabled: false
         )
 
-        viewModel.onStateChange = { state in
+        viewModel.onStateChange = { [gameCenterMatchCoordinator] state in
             Task {
                 do {
                     guard let current = activeGameCenterMatch else { return }
-                    let updated = try await GameCenterMatchCoordinator(ledgerCoordinator: coordinator)
-                        .commit(state: state, for: current)
+                    let updated = try await gameCenterMatchCoordinator.commit(state: state, for: current)
                     activeGameCenterMatch = updated
                 } catch {
                     routeError = error.localizedDescription
@@ -215,12 +268,11 @@ public struct RootView: View {
             }
         }
 
-        viewModel.onCompletion = { state in
+        viewModel.onCompletion = { [gameCenterMatchCoordinator] state in
             Task {
                 do {
                     guard let current = activeGameCenterMatch else { return }
-                    let updated = try await GameCenterMatchCoordinator(ledgerCoordinator: coordinator)
-                        .commit(state: state, for: current)
+                    let updated = try await gameCenterMatchCoordinator.commit(state: state, for: current)
                     activeGameCenterMatch = updated
                     completedRecord = coordinator.latestCompletedRecord
                 } catch {


### PR DESCRIPTION
## Summary

Reviewed the official `CreatingTurnBasedGames` sample against our Game Center plumbing and removed ceremony Apple's modern async APIs already cover.

- Drop the four `withCheckedThrowingContinuation` wrappers and `GameCenterTurnBasedMatchBox`; `GameCenterSession` is `@MainActor` with `@preconcurrency GKLocalPlayerListener` conformance and uses native async `loadMatches`/`loadMatchData`/`saveCurrentTurn`/`endTurn`/`endMatchInTurn`/`sendReminder`.
- Reload the `GKTurnBasedMatch` by ID inside `commit` and `sendReminder` (Apple's pattern) to avoid acting on stale cached match objects, and hoist a single `GameCenterMatchCoordinator` `@State` in `RootView` instead of three inline allocations.
- Set `setLocalizableMessageWithKey` on `endTurn` so the opponent's Game Center push notification carries a turn message; wire `wantsToQuitMatch` through the session and surface a "Remind" button on `OpponentTurnView` (Game Center matches only) backed by the existing coordinator method.

## Test plan

- [x] `./scripts/test.sh` (SwiftPM build + tests, Xcode iOS Simulator build, UI screenshot tests)
- [ ] Two-device GC: invite, take a turn, confirm the opponent's GC notification carries the turn message
- [ ] Tap "Remind" on the opponent-turn screen; confirm the opponent receives a reminder push
- [ ] Quit the match from Game Center's matchmaker UI; confirm the active match is cleared and the GC side is marked quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)