### PR TITLE
Set Game Center authenticateHandler at launch

### DIFF
--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -30,15 +30,13 @@ public final class GameCenterSession: NSObject, @preconcurrency GKLocalPlayerLis
     public var authenticationViewController: UIViewController?
     public var lastErrorMessage: String?
     private var authenticationAttemptID = UUID()
-    private var hasStarted = false
 
     @ObservationIgnored public var onTurnEvent: (@MainActor (GKTurnBasedMatch, Bool) -> Void)?
     @ObservationIgnored public var onMatchEnded: (@MainActor (GKTurnBasedMatch) -> Void)?
     @ObservationIgnored public var onWantsToQuitMatch: (@MainActor (GKTurnBasedMatch) -> Void)?
 
     public func start() {
-        guard !hasStarted else { return }
-        hasStarted = true
+        guard authState == .notStarted else { return }
         beginAuthentication()
     }
 

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -30,12 +30,24 @@ public final class GameCenterSession: NSObject, @preconcurrency GKLocalPlayerLis
     public var authenticationViewController: UIViewController?
     public var lastErrorMessage: String?
     private var authenticationAttemptID = UUID()
+    private var hasStarted = false
 
     @ObservationIgnored public var onTurnEvent: (@MainActor (GKTurnBasedMatch, Bool) -> Void)?
     @ObservationIgnored public var onMatchEnded: (@MainActor (GKTurnBasedMatch) -> Void)?
     @ObservationIgnored public var onWantsToQuitMatch: (@MainActor (GKTurnBasedMatch) -> Void)?
 
-    public func authenticate() {
+    public func start() {
+        guard !hasStarted else { return }
+        hasStarted = true
+        beginAuthentication()
+    }
+
+    public func retry() {
+        guard !authState.isAuthenticated, authState != .authenticating else { return }
+        beginAuthentication()
+    }
+
+    private func beginAuthentication() {
         let attemptID = UUID()
         authenticationAttemptID = attemptID
         authState = .authenticating
@@ -652,7 +664,7 @@ public struct GameCenterHomeView: View {
 
             if !session.authState.isAuthenticated {
                 Button {
-                    session.authenticate()
+                    session.retry()
                 } label: {
                     Label(authButtonTitle, systemImage: "person.crop.circle.badge.checkmark")
                         .frame(maxWidth: .infinity)
@@ -726,7 +738,7 @@ public struct GameCenterHomeView: View {
 
     private func startGameCenterInvite() {
         guard session.authState.isAuthenticated else {
-            session.authenticate()
+            session.retry()
             return
         }
         isShowingMatchmaker = true
@@ -825,7 +837,7 @@ private struct EmptyGameCenterLedgerView: View {
 }
 
 private struct AuthenticationController: Identifiable {
-    let id = UUID()
     let viewController: UIViewController
+    var id: ObjectIdentifier { ObjectIdentifier(viewController) }
 }
 #endif

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -197,6 +197,7 @@ public struct RootView: View {
         gameCenterSession.onWantsToQuitMatch = { match in
             Task { await handleWantsToQuit(match) }
         }
+        gameCenterSession.start()
     }
 
     private func loadAndOpenGameCenterMatch(_ match: GKTurnBasedMatch) async {


### PR DESCRIPTION
## Summary
- Tapping **Sign in to Game Center** did nothing because `GKLocalPlayer.authenticateHandler` was assigned lazily on tap rather than at launch (Apple's documented pattern). Split `GameCenterSession.authenticate()` into an idempotent `start()` called from `RootView.task` and a `retry()` bound to the Sign-in button and the invite-friend fallback.
- Stabilize `AuthenticationController.id` via `ObjectIdentifier(viewController)` so `.sheet(item:)` no longer thrashes when SwiftUI re-evaluates the binding and the GC sign-in sheet can present cleanly.

## Test plan
- [ ] Run on a device signed into Game Center: home view flips to "Signed in as …" without tapping anything.
- [ ] Run on a device signed out: GC sign-in sheet presents on launch and completes.
- [ ] Force a timeout (airplane mode at launch): "Game Center did not respond" alert after 12s, Sign in button re-enables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)