### PR TITLE
Add remove all active matches

### DIFF
--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -279,6 +279,12 @@ public final class GameCenterMatchCoordinator {
         }
     }
 
+    public func remove(loaded: GameCenterLoadedMatch) async throws {
+        try await quit(loaded: loaded)
+        let match = try await GKTurnBasedMatch.load(withID: loaded.match.matchID)
+        try await match.remove()
+    }
+
     private func reconcileLedger(
         for match: GKTurnBasedMatch,
         envelope: GameCenterMatchEnvelope,
@@ -521,6 +527,7 @@ public struct GameCenterHomeView: View {
     @State private var matches: [GameCenterLoadedMatch] = []
     @State private var isLoadingMatches = false
     @State private var isWorking = false
+    @State private var isShowingRemoveAllConfirmation = false
     @State private var isShowingMatchmaker = false
     @State private var selectedTargetScore = 7
     @State private var localError: String?
@@ -555,6 +562,14 @@ public struct GameCenterHomeView: View {
                         onPrimary: startAIRivalry,
                         onSecondary: startGameCenterInvite
                     )
+
+                    if activeMatches.count > 0 {
+                        RemoveAllMatchesButton(
+                            activeMatchCount: activeMatches.count,
+                            isDisabled: isWorking,
+                            action: { isShowingRemoveAllConfirmation = true }
+                        )
+                    }
 
                     if !session.authState.isAuthenticated {
                         authPanel
@@ -596,6 +611,14 @@ public struct GameCenterHomeView: View {
                 onError: { error in localError = error.localizedDescription }
             )
         }
+        .alert("Remove All Matches?", isPresented: $isShowingRemoveAllConfirmation) {
+            Button("Remove All Matches", role: .destructive) {
+                removeAllActiveMatches()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(removeAllConfirmationMessage)
+        }
         .alert(
             "Game Center Error",
             isPresented: Binding(
@@ -613,6 +636,35 @@ public struct GameCenterHomeView: View {
         } message: {
             Text(localError ?? session.lastErrorMessage ?? ledgerCoordinator.lastErrorMessage ?? "")
         }
+    }
+
+    private var activeMatches: [ActiveMatch] {
+        ledgerCoordinator.ledgers.compactMap(\.activeMatch)
+    }
+
+    private var localActiveMatches: [ActiveMatch] {
+        activeMatches.filter { $0.gameCenterMatchID == nil }
+    }
+
+    private var gameCenterActiveMatches: [ActiveMatch] {
+        activeMatches.filter { $0.gameCenterMatchID != nil }
+    }
+
+    private var loadedMatchesByID: [String: GameCenterLoadedMatch] {
+        Dictionary(matches.map { ($0.match.matchID, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    private var removeAllConfirmationMessage: String {
+        var parts: [String] = []
+        if gameCenterActiveMatches.count > 0 {
+            parts.append("forfeit \(matchPhrase(gameCenterActiveMatches.count)) in Game Center")
+        }
+        if localActiveMatches.count > 0 {
+            parts.append("clear \(matchPhrase(localActiveMatches.count)) locally")
+        }
+
+        let action = parts.isEmpty ? "remove active matches" : parts.joined(separator: " and ")
+        return "This will \(action). Completed rivalry history stays."
     }
 
     private var authenticationBinding: Binding<AuthenticationController?> {
@@ -724,6 +776,55 @@ public struct GameCenterHomeView: View {
         }
     }
 
+    private func removeAllActiveMatches() {
+        guard !isWorking else { return }
+
+        let localMatchesToClear = localActiveMatches
+        let gameCenterMatchesToRemove = gameCenterActiveMatches
+        guard !localMatchesToClear.isEmpty || !gameCenterMatchesToRemove.isEmpty else { return }
+
+        isWorking = true
+        Task {
+            defer { isWorking = false }
+
+            do {
+                if !localMatchesToClear.isEmpty {
+                    try await ledgerCoordinator.clearActiveMatches(localMatchesToClear)
+                }
+            } catch {
+                localError = error.localizedDescription
+                return
+            }
+
+            guard !gameCenterMatchesToRemove.isEmpty else { return }
+
+            await refresh()
+            let loadedByID = loadedMatchesByID
+            var failedGameCenterCount = 0
+
+            for activeMatch in gameCenterMatchesToRemove {
+                guard let gameCenterMatchID = activeMatch.gameCenterMatchID,
+                      let loaded = loadedByID[gameCenterMatchID] else {
+                    failedGameCenterCount += 1
+                    continue
+                }
+
+                do {
+                    try await matchCoordinator.remove(loaded: loaded)
+                    try await ledgerCoordinator.clearActiveMatches([activeMatch])
+                } catch {
+                    failedGameCenterCount += 1
+                }
+            }
+
+            await refresh()
+
+            if failedGameCenterCount > 0 {
+                localError = "\(failedGameCenterCount) Game Center \(failedGameCenterCount == 1 ? "match" : "matches") could not be forfeited. Those matches were left active."
+            }
+        }
+    }
+
     private func startGameCenterInvite() {
         guard session.authState.isAuthenticated else {
             session.authenticate()
@@ -797,6 +898,10 @@ public struct GameCenterHomeView: View {
         } catch {
             localError = error.localizedDescription
         }
+    }
+
+    private func matchPhrase(_ count: Int) -> String {
+        "\(count) active \(count == 1 ? "match" : "matches")"
     }
 }
 

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -787,20 +787,25 @@ public struct GameCenterHomeView: View {
         Task {
             defer { isWorking = false }
 
+            var failureMessages: [String] = []
+
             do {
                 if !localMatchesToClear.isEmpty {
                     try await ledgerCoordinator.clearActiveMatches(localMatchesToClear)
                 }
             } catch {
-                localError = error.localizedDescription
-                return
+                failureMessages.append("Local matches could not be cleared: \(error.localizedDescription)")
             }
 
-            guard !gameCenterMatchesToRemove.isEmpty else { return }
+            guard !gameCenterMatchesToRemove.isEmpty else {
+                localError = failureMessages.first
+                return
+            }
 
             await refresh()
             let loadedByID = loadedMatchesByID
             var failedGameCenterCount = 0
+            var successfullyRemoved: [ActiveMatch] = []
 
             for activeMatch in gameCenterMatchesToRemove {
                 guard let gameCenterMatchID = activeMatch.gameCenterMatchID,
@@ -811,17 +816,29 @@ public struct GameCenterHomeView: View {
 
                 do {
                     try await matchCoordinator.remove(loaded: loaded)
-                    try await ledgerCoordinator.clearActiveMatches([activeMatch])
+                    successfullyRemoved.append(activeMatch)
                 } catch {
                     failedGameCenterCount += 1
+                }
+            }
+
+            if !successfullyRemoved.isEmpty {
+                do {
+                    try await ledgerCoordinator.clearActiveMatches(successfullyRemoved)
+                } catch {
+                    failureMessages.append(
+                        "\(successfullyRemoved.count) forfeited Game Center \(successfullyRemoved.count == 1 ? "match" : "matches") could not be cleared locally: \(error.localizedDescription)"
+                    )
                 }
             }
 
             await refresh()
 
             if failedGameCenterCount > 0 {
-                localError = "\(failedGameCenterCount) Game Center \(failedGameCenterCount == 1 ? "match" : "matches") could not be forfeited. Those matches were left active."
+                failureMessages.append("\(failedGameCenterCount) Game Center \(failedGameCenterCount == 1 ? "match" : "matches") could not be forfeited. Those matches were left active.")
             }
+
+            localError = failureMessages.isEmpty ? nil : failureMessages.joined(separator: "\n")
         }
     }
 

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -12,6 +12,7 @@ public struct HomeView: View {
     @State private var isAddingRival = false
     @State private var newRivalName = ""
     @State private var isWorking = false
+    @State private var isShowingRemoveAllConfirmation = false
     @State private var localError: String?
 
     public init(
@@ -42,6 +43,14 @@ public struct HomeView: View {
                         }
                     )
 
+                    if activeMatches.count > 0 {
+                        RemoveAllMatchesButton(
+                            activeMatchCount: activeMatches.count,
+                            isDisabled: isWorking,
+                            action: { isShowingRemoveAllConfirmation = true }
+                        )
+                    }
+
                     if coordinator.ledgers.isEmpty {
                         EmptyLedgerView()
                     } else {
@@ -69,6 +78,14 @@ public struct HomeView: View {
         } message: {
             Text("Create a head-to-head ledger.")
         }
+        .alert("Remove All Matches?", isPresented: $isShowingRemoveAllConfirmation) {
+            Button("Remove All Matches", role: .destructive) {
+                removeAllActiveMatches()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(removeAllConfirmationMessage)
+        }
         .alert(
             "Ledger Error",
             isPresented: Binding(
@@ -85,6 +102,14 @@ public struct HomeView: View {
         } message: {
             Text(localError ?? coordinator.lastErrorMessage ?? "")
         }
+    }
+
+    private var activeMatches: [ActiveMatch] {
+        coordinator.ledgers.compactMap(\.activeMatch)
+    }
+
+    private var removeAllConfirmationMessage: String {
+        "This will clear \(activeMatches.count) active \(activeMatches.count == 1 ? "match" : "matches"). Completed rivalry history stays."
     }
 
     private var header: some View {
@@ -131,6 +156,22 @@ public struct HomeView: View {
         }
     }
 
+    private func removeAllActiveMatches() {
+        guard !isWorking else { return }
+        let matchesToClear = activeMatches
+        guard !matchesToClear.isEmpty else { return }
+
+        isWorking = true
+        Task {
+            do {
+                try await coordinator.clearActiveMatches(matchesToClear)
+            } catch {
+                localError = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
     private func startMatch(for ledger: RivalLedger) {
         guard !isWorking else { return }
         isWorking = true
@@ -147,6 +188,27 @@ public struct HomeView: View {
             }
             isWorking = false
         }
+    }
+}
+
+struct RemoveAllMatchesButton: View {
+    let activeMatchCount: Int
+    let isDisabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(role: .destructive, action: action) {
+            Label("Remove All Matches", systemImage: "trash")
+                .font(LedgerTheme.uiFont(size: 15, weight: .semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+        }
+        .buttonStyle(.bordered)
+        .tint(LedgerTheme.rust)
+        .disabled(isDisabled || activeMatchCount == 0)
+        .accessibilityIdentifier("home-remove-all-matches")
     }
 }
 

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -72,6 +72,13 @@ public final class LedgerCoordinator {
         await refresh()
     }
 
+    public func clearActiveMatches(_ matches: [ActiveMatch]) async throws {
+        for match in matches {
+            try await store.clearActiveMatch(rivalID: match.rivalID)
+        }
+        await refresh()
+    }
+
     public func recordCompletion(of match: ActiveMatch) async throws {
         let record = try makeRecord(from: match, completedAt: Date())
         try await store.saveActiveMatch(match)

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -138,6 +138,73 @@ struct LedgerCoordinatorTests {
         #expect(firstMatch.state.config.targetScore == 1)
     }
 
+    @Test("clearing active matches preserves rivals and completed records")
+    @MainActor
+    func clearActiveMatchesPreservesHistory() async throws {
+        let rival = Rival(displayName: "Dan")
+        let record = MatchRecord(
+            rivalID: rival.id,
+            userPlayed: .white,
+            winner: .you,
+            userScore: 7,
+            rivalScore: 3,
+            targetScore: 7,
+            startedAt: Date(timeIntervalSince1970: 100),
+            completedAt: Date(timeIntervalSince1970: 200)
+        )
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            userPlayed: .black,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        )
+        let store = InMemoryLedgerStore(rivals: [rival], records: [record], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+        try await coordinator.clearActiveMatches([active])
+
+        #expect(try await store.loadRivals() == [rival])
+        #expect(try await store.loadMatchRecords(rivalID: rival.id) == [record])
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
+        #expect(coordinator.ledger(for: rival.id)?.totalMatches == 1)
+        #expect(coordinator.ledger(for: rival.id)?.activeMatch == nil)
+    }
+
+    @Test("clearing multiple active matches leaves unselected active matches")
+    @MainActor
+    func clearMultipleActiveMatches() async throws {
+        let firstRival = Rival(displayName: "Dan")
+        let secondRival = Rival(displayName: "Lee")
+        let thirdRival = Rival(displayName: "Mira")
+        let firstActive = ActiveMatch(
+            rivalID: firstRival.id,
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 3))
+        )
+        let secondActive = ActiveMatch(
+            rivalID: secondRival.id,
+            userPlayed: .black,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 5))
+        )
+        let thirdActive = ActiveMatch(
+            rivalID: thirdRival.id,
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        )
+        let store = InMemoryLedgerStore(
+            rivals: [firstRival, secondRival, thirdRival],
+            activeMatches: [firstActive, secondActive, thirdActive]
+        )
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+        try await coordinator.clearActiveMatches([firstActive, secondActive])
+
+        #expect(try await store.loadActiveMatch(rivalID: firstRival.id) == nil)
+        #expect(try await store.loadActiveMatch(rivalID: secondRival.id) == nil)
+        #expect(try await store.loadActiveMatch(rivalID: thirdRival.id) == thirdActive)
+        #expect(coordinator.ledger(for: thirdRival.id)?.activeMatch == thirdActive)
+    }
 }
 
 private final class CompletionDiceRoller: DiceRolling, @unchecked Sendable {


### PR DESCRIPTION
Adds a root-view Remove All Matches action for active matches only. Local active matches are cleared while completed rivalry history and rivals are preserved. Game Center matches are forfeited through GameKit and removed before their local active records are cleared.\n\nTests: swift test; xcodebuild -scheme SheshBesh -destination 'generic/platform=iOS Simulator' build.