### PR TITLE
Fix Invite Friend opening existing match

### DIFF
--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -188,10 +188,18 @@ public struct RootView: View {
 
     #if canImport(GameKit) && canImport(UIKit)
     private func configureGameCenterCallbacks() {
-        gameCenterSession.onTurnEvent = { match, _ in
+        gameCenterSession.onTurnEvent = { match, didBecomeActive in
+            guard activeGameCenterMatch?.match.matchID == match.matchID || didBecomeActive else {
+                return
+            }
+
             Task { await loadAndOpenGameCenterMatch(match) }
         }
         gameCenterSession.onMatchEnded = { match in
+            guard activeGameCenterMatch?.match.matchID == match.matchID else {
+                return
+            }
+
             Task { await loadAndOpenGameCenterMatch(match) }
         }
         gameCenterSession.onWantsToQuitMatch = { match in

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -189,18 +189,28 @@ public struct RootView: View {
     #if canImport(GameKit) && canImport(UIKit)
     private func configureGameCenterCallbacks() {
         gameCenterSession.onTurnEvent = { match, didBecomeActive in
-            guard activeGameCenterMatch?.match.matchID == match.matchID || didBecomeActive else {
-                return
+            Task {
+                do {
+                    let loaded = try await gameCenterMatchCoordinator.load(match: match)
+                    if activeGameCenterMatch?.match.matchID == match.matchID || didBecomeActive {
+                        openGameCenterMatch(loaded)
+                    }
+                } catch {
+                    routeError = error.localizedDescription
+                }
             }
-
-            Task { await loadAndOpenGameCenterMatch(match) }
         }
         gameCenterSession.onMatchEnded = { match in
-            guard activeGameCenterMatch?.match.matchID == match.matchID else {
-                return
+            Task {
+                do {
+                    let loaded = try await gameCenterMatchCoordinator.load(match: match)
+                    if activeGameCenterMatch?.match.matchID == match.matchID {
+                        openGameCenterMatch(loaded)
+                    }
+                } catch {
+                    routeError = error.localizedDescription
+                }
             }
-
-            Task { await loadAndOpenGameCenterMatch(match) }
         }
         gameCenterSession.onWantsToQuitMatch = { match in
             Task { await handleWantsToQuit(match) }


### PR DESCRIPTION
## Summary
Fixes Game Center listener handling so pending offline turn events no longer automatically open an inactive match from the home screen. Delivered turn and ended-match events are still loaded through the Game Center coordinator so the local ledger refreshes in the background. Navigation remains conditional: turn events open only when Game Center marks the match active or when the event belongs to the currently visible match, and ended-match events only reload the currently visible match. This keeps Invite Friend on the standard matchmaker sheet instead of being displaced by an existing board.

## Verification
- swift test
- xcodebuild -project SheshBesh.xcodeproj -scheme SheshBesh -destination 'generic/platform=iOS Simulator' build