### PR TITLE
Animate checker movement

### DIFF
--- a/SheshBesh.xcodeproj/project.pbxproj
+++ b/SheshBesh.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AF1000000000000000000003 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1000000000000000000004 /* RootView.swift */; };
 		AF1000000000000000000005 /* MatchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1000000000000000000006 /* MatchViewModel.swift */; };
 		AF1000000000000000000007 /* BoardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1000000000000000000008 /* BoardView.swift */; };
+		AF5000000000000000000001 /* CheckerLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5000000000000000000002 /* CheckerLayout.swift */; };
 		AF1000000000000000000009 /* SheshBeshGame.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF100000000000000000000A /* SheshBeshGame.framework */; };
 		AF100000000000000000000B /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF100000000000000000000C /* Board.swift */; };
 		AF100000000000000000000D /* Dice.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF100000000000000000000E /* Dice.swift */; };
@@ -60,6 +61,7 @@
 		AF1000000000000000000004 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		AF1000000000000000000006 /* MatchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchViewModel.swift; sourceTree = "<group>"; };
 		AF1000000000000000000008 /* BoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardView.swift; sourceTree = "<group>"; };
+		AF5000000000000000000002 /* CheckerLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckerLayout.swift; sourceTree = "<group>"; };
 		AF100000000000000000000A /* SheshBeshGame.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SheshBeshGame.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF100000000000000000000C /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		AF100000000000000000000E /* Dice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dice.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 			children = (
 				AF1000000000000000000037 /* AppLaunchConfiguration.swift */,
 				AF1000000000000000000008 /* BoardView.swift */,
+				AF5000000000000000000002 /* CheckerLayout.swift */,
 				AF4000000000000000000002 /* GameCenterEnvelope.swift */,
 				AF4000000000000000000004 /* GameCenterSupport.swift */,
 				AF3000000000000000000004 /* HomeView.swift */,
@@ -373,6 +376,7 @@
 				AF1000000000000000000001 /* SheshBeshMain.swift in Sources */,
 				AF1000000000000000000036 /* AppLaunchConfiguration.swift in Sources */,
 				AF1000000000000000000007 /* BoardView.swift in Sources */,
+				AF5000000000000000000001 /* CheckerLayout.swift in Sources */,
 				AF4000000000000000000001 /* GameCenterEnvelope.swift in Sources */,
 				AF4000000000000000000003 /* GameCenterSupport.swift in Sources */,
 				AF3000000000000000000003 /* HomeView.swift in Sources */,

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -8,6 +8,7 @@ public struct BoardView: View {
     private let onBackToRivals: (() -> Void)?
 
     @State private var selectedSource: MoveSource?
+    @Namespace private var checkerNamespace
 
     public init(
         viewModel: MatchViewModel,
@@ -32,6 +33,7 @@ public struct BoardView: View {
 
                 BoardSurface(
                     viewModel: viewModel,
+                    checkerNamespace: checkerNamespace,
                     isReadOnly: isReadOnly,
                     selectedSource: selectedSource,
                     onPointTap: handlePointTap,
@@ -42,6 +44,7 @@ public struct BoardView: View {
 
                 BearOffStrip(
                     viewModel: viewModel,
+                    checkerNamespace: checkerNamespace,
                     selectedSource: selectedSource,
                     isReadOnly: isReadOnly,
                     onBearOffTap: handleBearOffTap
@@ -469,6 +472,7 @@ private struct PipStrip: View {
 
 private struct BoardSurface: View {
     let viewModel: MatchViewModel
+    let checkerNamespace: Namespace.ID
     let isReadOnly: Bool
     let selectedSource: MoveSource?
     let onPointTap: (PointID) -> Void
@@ -489,6 +493,7 @@ private struct BoardSurface: View {
             VStack(spacing: 0) {
                 BoardHalf(
                     viewModel: viewModel,
+                    checkerNamespace: checkerNamespace,
                     selectedSource: selectedSource,
                     leftPoints: pointLayout.topLeft,
                     rightPoints: pointLayout.topRight,
@@ -503,6 +508,7 @@ private struct BoardSurface: View {
 
                 TrayRow(
                     viewModel: viewModel,
+                    checkerNamespace: checkerNamespace,
                     selectedSource: selectedSource,
                     barWidth: barWidth,
                     onBarTap: onBarTap
@@ -511,6 +517,7 @@ private struct BoardSurface: View {
 
                 BoardHalf(
                     viewModel: viewModel,
+                    checkerNamespace: checkerNamespace,
                     selectedSource: selectedSource,
                     leftPoints: pointLayout.bottomLeft,
                     rightPoints: pointLayout.bottomRight,
@@ -566,6 +573,7 @@ private struct BoardPointLayout {
 
 private struct BoardHalf: View {
     let viewModel: MatchViewModel
+    let checkerNamespace: Namespace.ID
     let selectedSource: MoveSource?
     let leftPoints: [PointID]
     let rightPoints: [PointID]
@@ -580,6 +588,7 @@ private struct BoardHalf: View {
         HStack(spacing: 0) {
             PointRun(
                 viewModel: viewModel,
+                checkerNamespace: checkerNamespace,
                 selectedSource: selectedSource,
                 pointIDs: leftPoints,
                 pointsDown: pointsDown,
@@ -591,6 +600,7 @@ private struct BoardHalf: View {
 
             BarWell(
                 viewModel: viewModel,
+                checkerNamespace: checkerNamespace,
                 selectedSource: selectedSource,
                 segment: pointsDown ? .top : .bottom,
                 isLegalSource: legalSources.contains(.bar),
@@ -601,6 +611,7 @@ private struct BoardHalf: View {
 
             PointRun(
                 viewModel: viewModel,
+                checkerNamespace: checkerNamespace,
                 selectedSource: selectedSource,
                 pointIDs: rightPoints,
                 pointsDown: pointsDown,
@@ -615,6 +626,7 @@ private struct BoardHalf: View {
 
 private struct PointRun: View {
     let viewModel: MatchViewModel
+    let checkerNamespace: Namespace.ID
     let selectedSource: MoveSource?
     let pointIDs: [PointID]
     let pointsDown: Bool
@@ -629,6 +641,8 @@ private struct PointRun: View {
                 PointCell(
                     pointID: pointID,
                     point: viewModel.state.game.board.point(pointID),
+                    checkerIDs: viewModel.checkerLayout.slots[.point(pointID)] ?? [],
+                    checkerNamespace: checkerNamespace,
                     pointsDown: pointsDown,
                     isDarkPoint: (index.isMultiple(of: 2)) == startsWithDarkPoint,
                     isSelected: selectedSource == .point(pointID),
@@ -646,6 +660,8 @@ private struct PointRun: View {
 private struct PointCell: View {
     let pointID: PointID
     let point: PointState
+    let checkerIDs: [CheckerID]
+    let checkerNamespace: Namespace.ID
     let pointsDown: Bool
     let isDarkPoint: Bool
     let isSelected: Bool
@@ -661,7 +677,12 @@ private struct PointCell: View {
                     .fill(isDarkPoint ? LinenBrass.rust.opacity(0.68) : LinenBrass.cream.opacity(0.72))
                     .padding(.horizontal, 1)
 
-                CheckerStack(point: point, pointsDown: pointsDown, localPlayer: localPlayer)
+                CheckerStack(
+                    checkerIDs: checkerIDs,
+                    pointsDown: pointsDown,
+                    localPlayer: localPlayer,
+                    checkerNamespace: checkerNamespace
+                )
                     .padding(.vertical, 5)
                     .padding(.horizontal, 1)
 
@@ -748,33 +769,44 @@ private struct PointTriangle: Shape {
 }
 
 private struct CheckerStack: View {
-    let point: PointState
+    let checkerIDs: [CheckerID]
     let pointsDown: Bool
     let localPlayer: Player
+    let checkerNamespace: Namespace.ID
 
     var body: some View {
         GeometryReader { geometry in
-            let visibleCount = min(point.count, 5)
+            let visibleIDs = Array(checkerIDs.suffix(5))
+            let renderedIDs = pointsDown ? visibleIDs : Array(visibleIDs.reversed())
             let diameter = max(6, min(geometry.size.width * 0.88, geometry.size.height / 5.4))
             let spacing = max(-diameter * 0.12, -3)
 
             VStack(spacing: spacing) {
-                ForEach(0..<visibleCount, id: \.self) { _ in
-                    Checker(owner: point.owner, localPlayer: localPlayer)
-                        .frame(width: diameter, height: diameter)
+                if !pointsDown, checkerIDs.count > visibleIDs.count {
+                    checkerCountBadge
                 }
 
-                if point.count > visibleCount {
-                    Text("\(point.count)")
-                        .font(LinenBrass.uiFont(size: 10, weight: .bold))
-                        .foregroundStyle(LinenBrass.ink)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(LinenBrass.brass, in: Capsule())
+                ForEach(renderedIDs, id: \.self) { checkerID in
+                    Checker(owner: checkerID.player, localPlayer: localPlayer)
+                        .frame(width: diameter, height: diameter)
+                        .matchedGeometryEffect(id: checkerID, in: checkerNamespace)
+                }
+
+                if pointsDown, checkerIDs.count > visibleIDs.count {
+                    checkerCountBadge
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: pointsDown ? .top : .bottom)
         }
+    }
+
+    private var checkerCountBadge: some View {
+        Text("\(checkerIDs.count)")
+            .font(LinenBrass.uiFont(size: 10, weight: .bold))
+            .foregroundStyle(LinenBrass.ink)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(LinenBrass.brass, in: Capsule())
     }
 }
 
@@ -842,6 +874,7 @@ private enum BarSegment {
 
 private struct BarWell: View {
     let viewModel: MatchViewModel
+    let checkerNamespace: Namespace.ID
     let selectedSource: MoveSource?
     let segment: BarSegment
     let isLegalSource: Bool
@@ -879,17 +912,16 @@ private struct BarWell: View {
         .accessibilityIdentifier(accessibilityIdentifier)
     }
 
+    @ViewBuilder
     private func barCheckers(for player: Player) -> some View {
-        let count = viewModel.state.game.board.barCount(for: player)
-        return Group {
-            if count > 0 {
-                Checker(owner: player, localPlayer: viewModel.localPlayer)
-                    .overlay {
-                        Text("\(count)")
-                            .font(LinenBrass.uiFont(size: 10, weight: .bold))
-                            .foregroundStyle(player == viewModel.localPlayer ? LinenBrass.cream : LinenBrass.ink)
-                    }
-            }
+        let checkerIDs = viewModel.checkerLayout.slots[.bar(player)] ?? []
+        if !checkerIDs.isEmpty {
+            BarCheckerStack(
+                checkerIDs: checkerIDs,
+                localPlayer: viewModel.localPlayer,
+                checkerNamespace: checkerNamespace
+            )
+            .frame(height: 74)
         }
     }
 
@@ -930,8 +962,42 @@ private struct BarWell: View {
     }
 }
 
+private struct BarCheckerStack: View {
+    let checkerIDs: [CheckerID]
+    let localPlayer: Player
+    let checkerNamespace: Namespace.ID
+
+    var body: some View {
+        GeometryReader { geometry in
+            let visibleIDs = Array(checkerIDs.suffix(3))
+            let diameter = max(14, min(geometry.size.width * 0.72, geometry.size.height / 3.2, 28))
+            let spacing = -diameter * 0.24
+
+            VStack(spacing: spacing) {
+                ForEach(visibleIDs, id: \.self) { checkerID in
+                    Checker(owner: checkerID.player, localPlayer: localPlayer)
+                        .frame(width: diameter, height: diameter)
+                        .matchedGeometryEffect(id: checkerID, in: checkerNamespace)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .overlay(alignment: .topTrailing) {
+                if checkerIDs.count > visibleIDs.count {
+                    Text("\(checkerIDs.count)")
+                        .font(LinenBrass.uiFont(size: 9, weight: .bold))
+                        .foregroundStyle(LinenBrass.ink)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(LinenBrass.brass, in: Capsule())
+                }
+            }
+        }
+    }
+}
+
 private struct TrayRow: View {
     let viewModel: MatchViewModel
+    let checkerNamespace: Namespace.ID
     let selectedSource: MoveSource?
     let barWidth: CGFloat
     let onBarTap: () -> Void
@@ -944,6 +1010,7 @@ private struct TrayRow: View {
 
             BarWell(
                 viewModel: viewModel,
+                checkerNamespace: checkerNamespace,
                 selectedSource: selectedSource,
                 segment: .tray,
                 isLegalSource: viewModel.isLegalSource(.bar),
@@ -1004,17 +1071,23 @@ private struct TrayRow: View {
 
 private struct BearOffStrip: View {
     let viewModel: MatchViewModel
+    let checkerNamespace: Namespace.ID
     let selectedSource: MoveSource?
     let isReadOnly: Bool
     let onBearOffTap: () -> Void
 
     var body: some View {
+        let opponent = viewModel.localPlayer.opponent
+        let opponentCheckerIDs = viewModel.checkerLayout.slots[.off(opponent)] ?? []
+        let localCheckerIDs = viewModel.checkerLayout.slots[.off(viewModel.localPlayer)] ?? []
+
         HStack(spacing: 10) {
             BearOffZone(
-                title: "\(viewModel.displayName(for: viewModel.localPlayer.opponent)) off",
-                count: viewModel.state.game.board.borneOffCount(for: viewModel.localPlayer.opponent),
-                owner: viewModel.localPlayer.opponent,
+                title: "\(viewModel.displayName(for: opponent)) off",
+                checkerIDs: opponentCheckerIDs,
+                owner: opponent,
                 localPlayer: viewModel.localPlayer,
+                checkerNamespace: checkerNamespace,
                 isLegalDestination: false,
                 accessibilityIdentifier: "bear-off-opponent",
                 onTap: {}
@@ -1023,9 +1096,10 @@ private struct BearOffStrip: View {
 
             BearOffZone(
                 title: "You off",
-                count: viewModel.state.game.board.borneOffCount(for: viewModel.localPlayer),
+                checkerIDs: localCheckerIDs,
                 owner: viewModel.localPlayer,
                 localPlayer: viewModel.localPlayer,
+                checkerNamespace: checkerNamespace,
                 isLegalDestination: !isReadOnly && viewModel.isLegalDestination(.off, from: selectedSource),
                 accessibilityIdentifier: "bear-off-local",
                 onTap: onBearOffTap
@@ -1045,9 +1119,10 @@ private struct BearOffStrip: View {
 
 private struct BearOffZone: View {
     let title: String
-    let count: Int
+    let checkerIDs: [CheckerID]
     let owner: Player
     let localPlayer: Player
+    let checkerNamespace: Namespace.ID
     let isLegalDestination: Bool
     let accessibilityIdentifier: String
     let onTap: () -> Void
@@ -1055,16 +1130,13 @@ private struct BearOffZone: View {
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: 10) {
-                Checker(owner: owner, localPlayer: localPlayer)
-                    .frame(width: 28, height: 28)
-                    .opacity(count == 0 ? 0.38 : 1)
-                    .overlay {
-                        if count > 0 {
-                            Text("\(count)")
-                                .font(LinenBrass.uiFont(size: 10, weight: .bold))
-                                .foregroundStyle(owner == localPlayer ? LinenBrass.cream : LinenBrass.ink)
-                        }
-                    }
+                BearOffCheckerStack(
+                    checkerIDs: checkerIDs,
+                    owner: owner,
+                    localPlayer: localPlayer,
+                    checkerNamespace: checkerNamespace
+                )
+                .frame(width: 62, height: 32)
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(title)
@@ -1092,6 +1164,52 @@ private struct BearOffZone: View {
         .accessibilityElement(children: .ignore)
         .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private var count: Int {
+        checkerIDs.count
+    }
+}
+
+private struct BearOffCheckerStack: View {
+    let checkerIDs: [CheckerID]
+    let owner: Player
+    let localPlayer: Player
+    let checkerNamespace: Namespace.ID
+
+    var body: some View {
+        GeometryReader { geometry in
+            let visibleIDs = Array(checkerIDs.suffix(3))
+            let diameter = max(20, min(geometry.size.height * 0.86, 28))
+            let spacing = -diameter * 0.38
+
+            ZStack(alignment: .topTrailing) {
+                if visibleIDs.isEmpty {
+                    Checker(owner: owner, localPlayer: localPlayer)
+                        .frame(width: diameter, height: diameter)
+                        .opacity(0.32)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                } else {
+                    HStack(spacing: spacing) {
+                        ForEach(visibleIDs, id: \.self) { checkerID in
+                            Checker(owner: checkerID.player, localPlayer: localPlayer)
+                                .frame(width: diameter, height: diameter)
+                                .matchedGeometryEffect(id: checkerID, in: checkerNamespace)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+                }
+
+                if checkerIDs.count > visibleIDs.count {
+                    Text("\(checkerIDs.count)")
+                        .font(LinenBrass.uiFont(size: 9, weight: .bold))
+                        .foregroundStyle(LinenBrass.ink)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(LinenBrass.brass, in: Capsule())
+                }
+            }
+        }
     }
 }
 

--- a/SheshBesh/Shared/CheckerLayout.swift
+++ b/SheshBesh/Shared/CheckerLayout.swift
@@ -1,0 +1,102 @@
+import SheshBeshGame
+
+public struct CheckerID: Hashable, Sendable {
+    public let player: Player
+    public let index: Int
+
+    public init(player: Player, index: Int) {
+        self.player = player
+        self.index = index
+    }
+}
+
+public enum CheckerSlot: Hashable, Sendable {
+    case point(PointID)
+    case bar(Player)
+    case off(Player)
+}
+
+public struct CheckerLayout: Equatable, Sendable {
+    public var slots: [CheckerSlot: [CheckerID]]
+
+    public init(slots: [CheckerSlot: [CheckerID]]) {
+        self.slots = slots
+    }
+
+    public static func reconstructed(from board: Board) -> CheckerLayout {
+        var slots: [CheckerSlot: [CheckerID]] = [:]
+        var nextIndex: [Player: Int] = [.white: 0, .black: 0]
+
+        func append(_ count: Int, for player: Player, to slot: CheckerSlot) {
+            guard count > 0 else { return }
+            for _ in 0..<count {
+                let index = nextIndex[player, default: 0]
+                slots[slot, default: []].append(CheckerID(player: player, index: index))
+                nextIndex[player] = index + 1
+            }
+        }
+
+        for (offset, point) in board.points.enumerated() {
+            guard let owner = point.owner, let pointID = PointID(rawValue: offset + 1) else {
+                continue
+            }
+            append(point.count, for: owner, to: .point(pointID))
+        }
+
+        for player in Player.allCases {
+            append(board.barCount(for: player), for: player, to: .bar(player))
+            append(board.borneOffCount(for: player), for: player, to: .off(player))
+        }
+
+        return CheckerLayout(slots: slots)
+    }
+
+    public mutating func apply(_ move: Move) {
+        guard let movedID = pop(from: slot(for: move.source, player: move.player)) else {
+            return
+        }
+
+        if case .point(let point) = move.destination {
+            let destinationSlot = CheckerSlot.point(point)
+            if slots[destinationSlot]?.count == 1,
+               slots[destinationSlot]?.last?.player == move.player.opponent,
+               let hitID = pop(from: destinationSlot) {
+                slots[.bar(hitID.player), default: []].append(hitID)
+            }
+        }
+
+        slots[slot(for: move.destination, player: move.player), default: []].append(movedID)
+    }
+
+    private mutating func pop(from slot: CheckerSlot) -> CheckerID? {
+        guard var checkerIDs = slots[slot], let checkerID = checkerIDs.popLast() else {
+            return nil
+        }
+
+        if checkerIDs.isEmpty {
+            slots.removeValue(forKey: slot)
+        } else {
+            slots[slot] = checkerIDs
+        }
+
+        return checkerID
+    }
+
+    private func slot(for source: MoveSource, player: Player) -> CheckerSlot {
+        switch source {
+        case .bar:
+            .bar(player)
+        case .point(let point):
+            .point(point)
+        }
+    }
+
+    private func slot(for destination: MoveDestination, player: Player) -> CheckerSlot {
+        switch destination {
+        case .off:
+            .off(player)
+        case .point(let point):
+            .point(point)
+        }
+    }
+}

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -1,23 +1,27 @@
 import Foundation
 import Observation
 import SheshBeshGame
+import SwiftUI
 
 @MainActor
 @Observable
 public final class MatchViewModel {
+    private static let checkerMoveAnimation = Animation.spring(response: 0.32, dampingFraction: 0.82)
+
     private let engine: MatchEngine
     private let opponentController: LocalAIOpponent
     private let opponentDelay: @Sendable () async -> Void
     @ObservationIgnored private var opponentTask: Task<Void, Never>?
 
     public private(set) var state: MatchState
+    public private(set) var checkerLayout: CheckerLayout
     public private(set) var lastError: String?
     public private(set) var legalActions: [MatchAction]
     public private(set) var legalMoves: [Move]
     public private(set) var pipCounts: [Player: Int]
     public private(set) var isOpponentThinking: Bool
     public private(set) var turnNotice: String?
-    private var turnDraftSnapshots: [MatchState]
+    private var turnDraftSnapshots: [(state: MatchState, layout: CheckerLayout)]
 
     public let localPlayer: Player
     public let opponentName: String
@@ -48,6 +52,7 @@ public final class MatchViewModel {
 
         self.engine = engine
         self.state = initialState
+        self.checkerLayout = CheckerLayout.reconstructed(from: initialState.game.board)
         self.localPlayer = localPlayer
         self.opponentName = opponentName
         self.isOpponentAutoplayEnabled = isOpponentAutoplayEnabled
@@ -206,10 +211,25 @@ public final class MatchViewModel {
     private func apply(_ action: MatchAction, schedulesOpponent: Bool) {
         do {
             let hadCompletion = state.completion != nil
-            state = try engine.apply(action: action, to: state)
-            lastError = nil
-            turnDraftSnapshots.removeAll()
-            refreshDerivedState()
+            let nextState = try engine.apply(action: action, to: state)
+            let applyStateChanges = {
+                self.state = nextState
+                if case .move(let move) = action {
+                    self.checkerLayout.apply(move)
+                } else if action == .startNextGame {
+                    self.checkerLayout = CheckerLayout.reconstructed(from: nextState.game.board)
+                }
+                self.lastError = nil
+                self.turnDraftSnapshots.removeAll()
+                self.refreshDerivedState()
+            }
+
+            if case .move = action {
+                withAnimation(Self.checkerMoveAnimation, applyStateChanges)
+            } else {
+                applyStateChanges()
+            }
+
             notifyStorageCallbacks(hadCompletion: hadCompletion)
             if schedulesOpponent {
                 turnNotice = nil
@@ -255,7 +275,9 @@ public final class MatchViewModel {
     }
 
     public func restartMatch() {
-        state = MatchEngine.newMatch(config: state.config)
+        let nextState = MatchEngine.newMatch(config: state.config)
+        state = nextState
+        checkerLayout = CheckerLayout.reconstructed(from: nextState.game.board)
         lastError = nil
         turnDraftSnapshots.removeAll()
         didNotifyCompletion = false
@@ -277,11 +299,14 @@ public final class MatchViewModel {
     }
 
     public func undoLastMove() {
-        guard let previousState = turnDraftSnapshots.popLast() else { return }
-        state = previousState
-        lastError = nil
-        turnNotice = nil
-        refreshDerivedState()
+        guard let snapshot = turnDraftSnapshots.popLast() else { return }
+        withAnimation(Self.checkerMoveAnimation) {
+            state = snapshot.state
+            checkerLayout = snapshot.layout
+            lastError = nil
+            turnNotice = nil
+            refreshDerivedState()
+        }
     }
 
     @discardableResult
@@ -349,12 +374,16 @@ public final class MatchViewModel {
             return
         }
 
-        turnDraftSnapshots.append(state)
+        turnDraftSnapshots.append((state: state, layout: checkerLayout))
         do {
-            state = try engine.apply(action: .move(move), to: state)
-            lastError = nil
-            turnNotice = nil
-            refreshDerivedState()
+            let nextState = try engine.apply(action: .move(move), to: state)
+            withAnimation(Self.checkerMoveAnimation) {
+                state = nextState
+                checkerLayout.apply(move)
+                lastError = nil
+                turnNotice = nil
+                refreshDerivedState()
+            }
         } catch {
             _ = turnDraftSnapshots.popLast()
             lastError = friendlyErrorMessage(error)

--- a/SheshBeshTests/CheckerLayoutTests.swift
+++ b/SheshBeshTests/CheckerLayoutTests.swift
@@ -1,0 +1,78 @@
+import SheshBeshApp
+import SheshBeshGame
+import Testing
+
+@Suite("Checker layout")
+struct CheckerLayoutTests {
+    @Test("reconstructs the initial board with stable per-player identities")
+    func reconstructsInitialBoard() {
+        let layout = CheckerLayout.reconstructed(from: .initial())
+
+        #expect(layout.checkerCount(for: .white) == 15)
+        #expect(layout.checkerCount(for: .black) == 15)
+        #expect(layout.slots[.point(point(24))]?.count == 2)
+        #expect(layout.slots[.point(point(13))]?.count == 5)
+        #expect(layout.slots[.point(point(8))]?.count == 3)
+        #expect(layout.slots[.point(point(6))]?.count == 5)
+        #expect(layout.slots[.point(point(1))]?.count == 2)
+        #expect(layout.slots[.point(point(12))]?.count == 5)
+        #expect(layout.slots[.point(point(17))]?.count == 3)
+        #expect(layout.slots[.point(point(19))]?.count == 5)
+    }
+
+    @Test("applying a non-hit move pops the source and pushes the destination")
+    func appliesNonHitMove() {
+        var layout = CheckerLayout.reconstructed(from: .initial())
+        let source = CheckerSlot.point(point(24))
+        let destination = CheckerSlot.point(point(18))
+        let movedID = layout.slots[source]?.last
+
+        layout.apply(Move(player: .white, source: .point(point(24)), destination: .point(point(18)), die: 6))
+
+        #expect(layout.slots[source]?.count == 1)
+        #expect(layout.slots[destination]?.last == movedID)
+        #expect(layout.checkerCount(for: .white) == 15)
+        #expect(layout.checkerCount(for: .black) == 15)
+    }
+
+    @Test("applying a hit sends the opponent blot to the bar")
+    func appliesHitMove() throws {
+        var board = Board.empty()
+        try board.setPoint(point(6), owner: .white, count: 1)
+        try board.setPoint(point(5), owner: .black, count: 1)
+        var layout = CheckerLayout.reconstructed(from: board)
+
+        let movedID = layout.slots[.point(point(6))]?.last
+        let hitID = layout.slots[.point(point(5))]?.last
+        layout.apply(Move(player: .white, source: .point(point(6)), destination: .point(point(5)), die: 1))
+
+        #expect(layout.slots[.point(point(6))] == nil)
+        #expect(layout.slots[.point(point(5))] == movedID.map { [$0] })
+        #expect(layout.slots[.bar(.black)] == hitID.map { [$0] })
+    }
+
+    @Test("applying a bear-off pushes the checker to the off slot")
+    func appliesBearOffMove() throws {
+        var board = Board.empty()
+        try board.setPoint(point(1), owner: .white, count: 1)
+        var layout = CheckerLayout.reconstructed(from: board)
+        let movedID = layout.slots[.point(point(1))]?.last
+
+        layout.apply(Move(player: .white, source: .point(point(1)), destination: .off, die: 1))
+
+        #expect(layout.slots[.point(point(1))] == nil)
+        #expect(layout.slots[.off(.white)] == movedID.map { [$0] })
+    }
+}
+
+private extension CheckerLayout {
+    func checkerCount(for player: Player) -> Int {
+        slots.values.reduce(0) { total, checkerIDs in
+            total + checkerIDs.filter { $0.player == player }.count
+        }
+    }
+}
+
+private func point(_ rawValue: Int) -> PointID {
+    PointID(rawValue: rawValue)!
+}

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -108,11 +108,13 @@ struct MatchViewModelTests {
 
         viewModel.rollOpeningDice()
         let rolledState = viewModel.state
+        let rolledLayout = viewModel.checkerLayout
 
         #expect(viewModel.applyMove(from: .point(PointID(rawValue: 24)!), to: .point(PointID(rawValue: 18)!)))
         viewModel.undoLastMove()
 
         #expect(viewModel.state == rolledState)
+        #expect(viewModel.checkerLayout == rolledLayout)
         #expect(!viewModel.isTurnDraftPending)
         #expect(!viewModel.canUndoTurnMove)
         #expect(viewModel.lastError == nil)


### PR DESCRIPTION
Adds view-layer checker IDs and layout tracking so point, bar, and bear-off checkers animate with matchedGeometryEffect during moves, hits, re-entry, bear-off, undo, and opponent play.

Wires MatchViewModel to snapshot and restore layout for drafted moves and reset it for new games without changing the game model.

Adds CheckerLayout unit tests and extends undo coverage.

Verified with swift test, swift test --package-path Packages/SheshBeshGame, xcodebuild build on iPhone 16, and SheshBeshUITests on iPhone 16.