### PR TITLE
Treat Swift warnings as errors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 
@@ -19,6 +19,7 @@ var targets: [Target] = [
         path: "Packages/SheshBeshGame/Sources/SheshBeshGame",
         swiftSettings: [
             .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .target(
@@ -27,6 +28,7 @@ var targets: [Target] = [
         path: "Packages/SheshBeshLedger/Sources/SheshBeshLedger",
         swiftSettings: [
             .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -35,6 +37,7 @@ var targets: [Target] = [
         path: "Packages/SheshBeshGame/Tests/SheshBeshGameTests",
         swiftSettings: [
             .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
     .testTarget(
@@ -43,6 +46,7 @@ var targets: [Target] = [
         path: "Packages/SheshBeshLedger/Tests/SheshBeshLedgerTests",
         swiftSettings: [
             .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     ),
 ]
@@ -62,6 +66,7 @@ targets.append(
         path: "SheshBesh/Shared",
         swiftSettings: [
             .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     )
 )
@@ -73,6 +78,7 @@ targets.append(
         path: "SheshBeshTests",
         swiftSettings: [
             .swiftLanguageMode(.v6),
+            .treatAllWarnings(as: .error),
         ]
     )
 )

--- a/SheshBesh.xcodeproj/project.pbxproj
+++ b/SheshBesh.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
@@ -508,6 +509,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
 				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -120,7 +120,7 @@ public final class GameCenterSession: NSObject, @preconcurrency GKLocalPlayerLis
     }
 
     public func loadMatches() async throws -> [GKTurnBasedMatch] {
-        try await GKTurnBasedMatch.loadMatches() ?? []
+        try await GKTurnBasedMatch.loadMatches()
     }
 
     public func player(


### PR DESCRIPTION
## Summary
- Enable `.treatAllWarnings(as: .error)` on every SPM target (bumps `swift-tools-version` to 6.2 since the API requires it).
- Add `SWIFT_TREAT_WARNINGS_AS_ERRORS = YES` to the Xcode project's Debug + Release configs so iOS app/test/UI-test builds enforce it too.
- Drop a now-dead `?? []` from `GameCenterSession.loadMatches()` — `GKTurnBasedMatch.loadMatches()` is non-optional in the current SDK, which the new flag surfaced.

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 123 tests pass
- [x] `xcodebuild -destination 'generic/platform=iOS Simulator' clean build` — zero warnings, BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)