### PR TITLE
Shrink rivals back button to a chevron icon

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -391,14 +391,12 @@ private struct HeaderCard: View {
             HStack(alignment: .center, spacing: 10) {
                 if let onBackToRivals {
                     Button(action: onBackToRivals) {
-                        Label("Rivals", systemImage: "chevron.left")
-                            .font(LinenBrass.uiFont(size: 14, weight: .semibold))
-                            .labelStyle(.titleAndIcon)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.78)
+                        Image(systemName: "chevron.left")
+                            .font(LinenBrass.uiFont(size: 16, weight: .semibold))
                     }
-                    .buttonStyle(.bordered)
-                    .tint(LinenBrass.coffee)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(LinenBrass.coffee)
+                    .accessibilityLabel("Back to rivals")
                     .accessibilityIdentifier("match-back-button")
                 }
 

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -393,6 +393,8 @@ private struct HeaderCard: View {
                     Button(action: onBackToRivals) {
                         Image(systemName: "chevron.left")
                             .font(LinenBrass.uiFont(size: 16, weight: .semibold))
+                            .frame(width: 44, height: 44, alignment: .leading)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .foregroundStyle(LinenBrass.coffee)


### PR DESCRIPTION
## Summary
- Replace the bordered "Rivals" back button in the match header with a plain `chevron.left` icon (accessibility label preserved).

## Test plan
- [ ] Open a match and confirm the back chevron renders compactly and still navigates back to the rivals list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)