### PR TITLE
Add swipe delete for rivalries

### DIFF
--- a/Packages/SheshBeshLedger/Sources/SheshBeshLedger/InMemoryLedgerStore.swift
+++ b/Packages/SheshBeshLedger/Sources/SheshBeshLedger/InMemoryLedgerStore.swift
@@ -45,6 +45,10 @@ public actor InMemoryLedgerStore: LedgerStore {
         recordsByRival[record.rivalID, default: []].append(record)
     }
 
+    public func deleteMatchRecords(rivalID: Rival.ID) async throws {
+        recordsByRival[rivalID] = nil
+    }
+
     public func loadActiveMatch(rivalID: Rival.ID) async throws -> ActiveMatch? {
         activeMatchesByRival[rivalID]
     }

--- a/Packages/SheshBeshLedger/Sources/SheshBeshLedger/JSONLedgerStore.swift
+++ b/Packages/SheshBeshLedger/Sources/SheshBeshLedger/JSONLedgerStore.swift
@@ -60,6 +60,11 @@ public actor JSONLedgerStore: LedgerStore {
         try persist()
     }
 
+    public func deleteMatchRecords(rivalID: Rival.ID) async throws {
+        snapshot.records.removeAll { $0.rivalID == rivalID }
+        try persist()
+    }
+
     public func loadActiveMatch(rivalID: Rival.ID) async throws -> ActiveMatch? {
         snapshot.activeMatches.first { $0.rivalID == rivalID }
     }

--- a/Packages/SheshBeshLedger/Sources/SheshBeshLedger/LedgerStore.swift
+++ b/Packages/SheshBeshLedger/Sources/SheshBeshLedger/LedgerStore.swift
@@ -7,6 +7,7 @@ public protocol LedgerStore: Sendable {
 
     func loadMatchRecords(rivalID: Rival.ID) async throws -> [MatchRecord]
     func appendMatchRecord(_ record: MatchRecord) async throws
+    func deleteMatchRecords(rivalID: Rival.ID) async throws
 
     func loadActiveMatch(rivalID: Rival.ID) async throws -> ActiveMatch?
     func saveActiveMatch(_ match: ActiveMatch) async throws

--- a/Packages/SheshBeshLedger/Tests/SheshBeshLedgerTests/InMemoryLedgerStoreTests.swift
+++ b/Packages/SheshBeshLedger/Tests/SheshBeshLedgerTests/InMemoryLedgerStoreTests.swift
@@ -55,6 +55,22 @@ struct InMemoryLedgerStoreTests {
         let records = try await store.loadMatchRecords(rivalID: rival.id)
         #expect(Set(records.map(\.id)) == Set([first.id, second.id]))
     }
+
+    @Test("match records can be deleted for one rival")
+    func deleteMatchRecords() async throws {
+        let store = InMemoryLedgerStore()
+        let firstRival = Rival(displayName: "Dan")
+        let secondRival = Rival(displayName: "Lee")
+        let firstRecord = record(rivalID: firstRival.id, id: UUID(), winner: .you)
+        let secondRecord = record(rivalID: secondRival.id, id: UUID(), winner: .rival)
+
+        try await store.appendMatchRecord(firstRecord)
+        try await store.appendMatchRecord(secondRecord)
+        try await store.deleteMatchRecords(rivalID: firstRival.id)
+
+        #expect(try await store.loadMatchRecords(rivalID: firstRival.id).isEmpty)
+        #expect(try await store.loadMatchRecords(rivalID: secondRival.id) == [secondRecord])
+    }
 }
 
 private func record(rivalID: Rival.ID, id: UUID, winner: MatchOutcome) -> MatchRecord {

--- a/Packages/SheshBeshLedger/Tests/SheshBeshLedgerTests/JSONLedgerStoreTests.swift
+++ b/Packages/SheshBeshLedger/Tests/SheshBeshLedgerTests/JSONLedgerStoreTests.swift
@@ -47,4 +47,46 @@ struct JSONLedgerStoreTests {
         let directoryContents = try fileManager.contentsOfDirectory(atPath: directoryURL.path)
         #expect(!directoryContents.contains(".ledger.json.tmp"))
     }
+
+    @Test("match record deletion persists")
+    func deleteMatchRecordsPersists() async throws {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = directoryURL.appendingPathComponent("ledger.json")
+        defer {
+            try? fileManager.removeItem(at: directoryURL)
+        }
+
+        let firstRival = Rival(displayName: "Dan")
+        let secondRival = Rival(displayName: "Lee")
+        let firstRecord = MatchRecord(
+            rivalID: firstRival.id,
+            userPlayed: .white,
+            winner: .you,
+            userScore: 7,
+            rivalScore: 2,
+            targetScore: 7,
+            startedAt: Date(timeIntervalSince1970: 100),
+            completedAt: Date(timeIntervalSince1970: 200)
+        )
+        let secondRecord = MatchRecord(
+            rivalID: secondRival.id,
+            userPlayed: .black,
+            winner: .rival,
+            userScore: 3,
+            rivalScore: 7,
+            targetScore: 7,
+            startedAt: Date(timeIntervalSince1970: 300),
+            completedAt: Date(timeIntervalSince1970: 400)
+        )
+
+        let writer = try JSONLedgerStore(fileURL: fileURL)
+        try await writer.appendMatchRecord(firstRecord)
+        try await writer.appendMatchRecord(secondRecord)
+        try await writer.deleteMatchRecords(rivalID: firstRival.id)
+
+        let reader = try JSONLedgerStore(fileURL: fileURL)
+        #expect(try await reader.loadMatchRecords(rivalID: firstRival.id).isEmpty)
+        #expect(try await reader.loadMatchRecords(rivalID: secondRival.id) == [secondRecord])
+    }
 }

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -539,6 +539,7 @@ public struct GameCenterHomeView: View {
     @State private var isWorking = false
     @State private var isShowingRemoveAllConfirmation = false
     @State private var isShowingMatchmaker = false
+    @State private var deletionRequest: RivalryDeletionRequest?
     @State private var selectedTargetScore = 7
     @State private var localError: String?
 
@@ -561,46 +562,50 @@ public struct GameCenterHomeView: View {
             LedgerBackground()
                 .ignoresSafeArea()
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    header
-                    RivalryLaunchActions(
-                        primaryTitle: "Practice vs AI",
-                        primarySystemImage: "cpu",
-                        secondaryTitle: "Invite Friend",
-                        secondarySystemImage: "person.badge.plus",
-                        onPrimary: startAIRivalry,
-                        onSecondary: startGameCenterInvite
+            List {
+                header
+                    .ledgerListRow(top: 18, bottom: 18)
+                RivalryLaunchActions(
+                    primaryTitle: "Practice vs AI",
+                    primarySystemImage: "cpu",
+                    secondaryTitle: "Invite Friend",
+                    secondarySystemImage: "person.badge.plus",
+                    onPrimary: startAIRivalry,
+                    onSecondary: startGameCenterInvite
+                )
+                .ledgerListRow(bottom: activeMatches.count > 0 ? 18 : 14)
+
+                if activeMatches.count > 0 {
+                    RemoveAllMatchesButton(
+                        activeMatchCount: activeMatches.count,
+                        isDisabled: isWorking,
+                        action: { isShowingRemoveAllConfirmation = true }
                     )
-
-                    if activeMatches.count > 0 {
-                        RemoveAllMatchesButton(
-                            activeMatchCount: activeMatches.count,
-                            isDisabled: isWorking,
-                            action: { isShowingRemoveAllConfirmation = true }
-                        )
-                    }
-
-                    if !session.authState.isAuthenticated {
-                        authPanel
-                    }
-
-                    if ledgerCoordinator.ledgers.isEmpty {
-                        EmptyGameCenterLedgerView()
-                    } else {
-                        RivalryStack(
-                            ledgers: ledgerCoordinator.ledgers,
-                            onStart: startMatch,
-                            onResume: resumeMatch,
-                            startTitle: startTitle,
-                            startSystemImage: startSystemImage
-                        )
-                    }
+                    .ledgerListRow(bottom: 18)
                 }
-                .padding(.horizontal, 18)
-                .padding(.top, 18)
-                .padding(.bottom, 28)
+
+                if !session.authState.isAuthenticated {
+                    authPanel
+                        .ledgerListRow(bottom: 18)
+                }
+
+                if ledgerCoordinator.ledgers.isEmpty {
+                    EmptyGameCenterLedgerView()
+                        .ledgerListRow(bottom: 28)
+                } else {
+                    RivalryStack(
+                        ledgers: ledgerCoordinator.ledgers,
+                        onStart: startMatch,
+                        onResume: resumeMatch,
+                        onDelete: requestDelete,
+                        startTitle: startTitle,
+                        startSystemImage: startSystemImage
+                    )
+                }
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Color.clear)
         }
         .task {
             await refresh()
@@ -628,6 +633,18 @@ public struct GameCenterHomeView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(removeAllConfirmationMessage)
+        }
+        .alert("Delete Rivalry?", isPresented: deletionConfirmationBinding) {
+            if let request = deletionRequest {
+                Button("Delete Rivalry", role: .destructive) {
+                    deleteRival(request.ledger, deletingRecords: true)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let request = deletionRequest {
+                Text(deleteConfirmationMessage(for: request.ledger))
+            }
         }
         .alert(
             "Game Center Error",
@@ -675,6 +692,20 @@ public struct GameCenterHomeView: View {
 
         let action = parts.isEmpty ? "remove active matches" : parts.joined(separator: " and ")
         return "This will \(action). Completed rivalry history stays."
+    }
+
+    private var deletionConfirmationBinding: Binding<Bool> {
+        Binding {
+            deletionRequest != nil
+        } set: { isPresented in
+            if !isPresented {
+                deletionRequest = nil
+            }
+        }
+    }
+
+    private func deleteConfirmationMessage(for ledger: RivalLedger) -> String {
+        "This rivalry has \(ledger.totalMatches) completed \(ledger.totalMatches == 1 ? "match" : "matches"). Delete anyway?"
     }
 
     private var authenticationBinding: Binding<AuthenticationController?> {
@@ -849,6 +880,38 @@ public struct GameCenterHomeView: View {
             }
 
             localError = failureMessages.isEmpty ? nil : failureMessages.joined(separator: "\n")
+        }
+    }
+
+    private func requestDelete(_ ledger: RivalLedger) {
+        guard !isWorking else { return }
+        if ledger.totalMatches > 0 {
+            deletionRequest = RivalryDeletionRequest(ledger: ledger)
+        } else {
+            deleteRival(ledger, deletingRecords: false)
+        }
+    }
+
+    private func deleteRival(_ ledger: RivalLedger, deletingRecords: Bool) {
+        guard !isWorking else { return }
+        isWorking = true
+        Task {
+            defer { isWorking = false }
+
+            do {
+                if let gameCenterMatchID = ledger.activeMatch?.gameCenterMatchID {
+                    await refresh()
+                    if let loaded = loadedMatchesByID[gameCenterMatchID] {
+                        try await matchCoordinator.remove(loaded: loaded)
+                    }
+                }
+
+                try await ledgerCoordinator.deleteRival(ledger.rival, deletingRecords: deletingRecords)
+                await refresh()
+                localError = nil
+            } catch {
+                localError = error.localizedDescription
+            }
         }
     }
 

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -13,6 +13,7 @@ public struct HomeView: View {
     @State private var newRivalName = ""
     @State private var isWorking = false
     @State private var isShowingRemoveAllConfirmation = false
+    @State private var deletionRequest: RivalryDeletionRequest?
     @State private var localError: String?
 
     public init(
@@ -28,43 +29,46 @@ public struct HomeView: View {
             LedgerBackground()
                 .ignoresSafeArea()
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    header
-                    RivalryLaunchActions(
-                        primaryTitle: "Practice vs AI",
-                        primarySystemImage: "cpu",
-                        secondaryTitle: "Add Rival",
-                        secondarySystemImage: "person.badge.plus",
-                        onPrimary: startAIRivalry,
-                        onSecondary: {
-                            newRivalName = ""
-                            isAddingRival = true
-                        }
+            List {
+                header
+                    .ledgerListRow(top: 18, bottom: 18)
+                RivalryLaunchActions(
+                    primaryTitle: "Practice vs AI",
+                    primarySystemImage: "cpu",
+                    secondaryTitle: "Add Rival",
+                    secondarySystemImage: "person.badge.plus",
+                    onPrimary: startAIRivalry,
+                    onSecondary: {
+                        newRivalName = ""
+                        isAddingRival = true
+                    }
+                )
+                .ledgerListRow(bottom: activeMatches.count > 0 ? 18 : 14)
+
+                if activeMatches.count > 0 {
+                    RemoveAllMatchesButton(
+                        activeMatchCount: activeMatches.count,
+                        isDisabled: isWorking,
+                        action: { isShowingRemoveAllConfirmation = true }
                     )
-
-                    if activeMatches.count > 0 {
-                        RemoveAllMatchesButton(
-                            activeMatchCount: activeMatches.count,
-                            isDisabled: isWorking,
-                            action: { isShowingRemoveAllConfirmation = true }
-                        )
-                    }
-
-                    if coordinator.ledgers.isEmpty {
-                        EmptyLedgerView()
-                    } else {
-                        RivalryStack(
-                            ledgers: coordinator.ledgers,
-                            onStart: startMatch,
-                            onResume: onOpenMatch
-                        )
-                    }
+                    .ledgerListRow(bottom: 18)
                 }
-                .padding(.horizontal, 18)
-                .padding(.top, 18)
-                .padding(.bottom, 28)
+
+                if coordinator.ledgers.isEmpty {
+                    EmptyLedgerView()
+                        .ledgerListRow(bottom: 28)
+                } else {
+                    RivalryStack(
+                        ledgers: coordinator.ledgers,
+                        onStart: startMatch,
+                        onResume: onOpenMatch,
+                        onDelete: requestDelete
+                    )
+                }
             }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Color.clear)
         }
         .task {
             await coordinator.refresh()
@@ -85,6 +89,18 @@ public struct HomeView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text(removeAllConfirmationMessage)
+        }
+        .alert("Delete Rivalry?", isPresented: deletionConfirmationBinding) {
+            if let request = deletionRequest {
+                Button("Delete Rivalry", role: .destructive) {
+                    deleteRival(request.ledger, deletingRecords: true)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if let request = deletionRequest {
+                Text(deleteConfirmationMessage(for: request.ledger))
+            }
         }
         .alert(
             "Ledger Error",
@@ -110,6 +126,20 @@ public struct HomeView: View {
 
     private var removeAllConfirmationMessage: String {
         "This will clear \(activeMatches.count) active \(activeMatches.count == 1 ? "match" : "matches"). Completed rivalry history stays."
+    }
+
+    private var deletionConfirmationBinding: Binding<Bool> {
+        Binding {
+            deletionRequest != nil
+        } set: { isPresented in
+            if !isPresented {
+                deletionRequest = nil
+            }
+        }
+    }
+
+    private func deleteConfirmationMessage(for ledger: RivalLedger) -> String {
+        "This rivalry has \(ledger.totalMatches) completed \(ledger.totalMatches == 1 ? "match" : "matches"). Delete anyway?"
     }
 
     private var header: some View {
@@ -172,6 +202,28 @@ public struct HomeView: View {
         }
     }
 
+    private func requestDelete(_ ledger: RivalLedger) {
+        guard !isWorking else { return }
+        if ledger.totalMatches > 0 {
+            deletionRequest = RivalryDeletionRequest(ledger: ledger)
+        } else {
+            deleteRival(ledger, deletingRecords: false)
+        }
+    }
+
+    private func deleteRival(_ ledger: RivalLedger, deletingRecords: Bool) {
+        guard !isWorking else { return }
+        isWorking = true
+        Task {
+            do {
+                try await coordinator.deleteRival(ledger.rival, deletingRecords: deletingRecords)
+            } catch {
+                localError = error.localizedDescription
+            }
+            isWorking = false
+        }
+    }
+
     private func startMatch(for ledger: RivalLedger) {
         guard !isWorking else { return }
         isWorking = true
@@ -189,6 +241,11 @@ public struct HomeView: View {
             isWorking = false
         }
     }
+}
+
+struct RivalryDeletionRequest: Identifiable {
+    let ledger: RivalLedger
+    var id: Rival.ID { ledger.rival.id }
 }
 
 struct RemoveAllMatchesButton: View {
@@ -253,6 +310,7 @@ struct RivalryStack: View {
     let ledgers: [RivalLedger]
     let onStart: (RivalLedger) -> Void
     let onResume: (ActiveMatch) -> Void
+    var onDelete: (RivalLedger) -> Void = { _ in }
     var startTitle: (RivalLedger) -> String = { _ in "Start match" }
     var startSystemImage: (RivalLedger) -> String = { _ in "play.fill" }
     var resumeTitle: (RivalLedger) -> String = { ledger in
@@ -263,39 +321,28 @@ struct RivalryStack: View {
     }
 
     var body: some View {
-        VStack(spacing: 14) {
-            if let hero = ledgers.first {
-                RivalryCard(
-                    ledger: hero,
-                    isHero: true,
-                    startTitle: startTitle(hero),
-                    startSystemImage: startSystemImage(hero),
-                    resumeTitle: resumeTitle(hero),
-                    resumeSystemImage: resumeSystemImage(hero),
-                    onStart: { onStart(hero) },
-                    onResume: {
-                        if let match = hero.activeMatch {
-                            onResume(match)
-                        }
+        ForEach(Array(ledgers.enumerated()), id: \.element.rival.id) { index, ledger in
+            RivalryCard(
+                ledger: ledger,
+                isHero: index == 0,
+                startTitle: startTitle(ledger),
+                startSystemImage: startSystemImage(ledger),
+                resumeTitle: resumeTitle(ledger),
+                resumeSystemImage: resumeSystemImage(ledger),
+                onStart: { onStart(ledger) },
+                onResume: {
+                    if let match = ledger.activeMatch {
+                        onResume(match)
                     }
-                )
-            }
-
-            ForEach(ledgers.dropFirst(), id: \.rival.id) { ledger in
-                RivalryCard(
-                    ledger: ledger,
-                    isHero: false,
-                    startTitle: startTitle(ledger),
-                    startSystemImage: startSystemImage(ledger),
-                    resumeTitle: resumeTitle(ledger),
-                    resumeSystemImage: resumeSystemImage(ledger),
-                    onStart: { onStart(ledger) },
-                    onResume: {
-                        if let match = ledger.activeMatch {
-                            onResume(match)
-                        }
-                    }
-                )
+                }
+            )
+            .ledgerListRow(bottom: index == ledgers.count - 1 ? 28 : 14)
+            .swipeActions(edge: .trailing) {
+                Button(role: .destructive) {
+                    onDelete(ledger)
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
             }
         }
     }
@@ -490,5 +537,13 @@ enum LedgerTheme {
 
     static func uiFont(size: CGFloat, weight: Font.Weight = .regular) -> Font {
         .system(size: size, weight: weight, design: .default)
+    }
+}
+
+extension View {
+    func ledgerListRow(top: CGFloat = 0, bottom: CGFloat) -> some View {
+        listRowInsets(EdgeInsets(top: top, leading: 18, bottom: bottom, trailing: 18))
+            .listRowSeparator(.hidden)
+            .listRowBackground(Color.clear)
     }
 }

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -215,12 +215,12 @@ public struct HomeView: View {
         guard !isWorking else { return }
         isWorking = true
         Task {
+            defer { isWorking = false }
             do {
                 try await coordinator.deleteRival(ledger.rival, deletingRecords: deletingRecords)
             } catch {
                 localError = error.localizedDescription
             }
-            isWorking = false
         }
     }
 

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -79,6 +79,22 @@ public final class LedgerCoordinator {
         await refresh()
     }
 
+    public func deleteRival(_ rival: Rival, deletingRecords: Bool = false) async throws {
+        let records = try await store.loadMatchRecords(rivalID: rival.id)
+        guard deletingRecords || records.isEmpty else {
+            throw LedgerStoreError.rivalHasHistory
+        }
+
+        if try await store.loadActiveMatch(rivalID: rival.id) != nil {
+            try await store.clearActiveMatch(rivalID: rival.id)
+        }
+        if deletingRecords {
+            try await store.deleteMatchRecords(rivalID: rival.id)
+        }
+        try await store.deleteRival(id: rival.id)
+        await refresh()
+    }
+
     public func recordCompletion(of match: ActiveMatch) async throws {
         let record = try makeRecord(from: match, completedAt: Date())
         try await store.saveActiveMatch(match)

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -205,6 +205,89 @@ struct LedgerCoordinatorTests {
         #expect(try await store.loadActiveMatch(rivalID: thirdRival.id) == thirdActive)
         #expect(coordinator.ledger(for: thirdRival.id)?.activeMatch == thirdActive)
     }
+
+    @Test("deleting clean rival removes the rival")
+    @MainActor
+    func deleteCleanRival() async throws {
+        let store = InMemoryLedgerStore()
+        let coordinator = LedgerCoordinator(store: store)
+        let rival = try await coordinator.addRival(displayName: "Dan")
+
+        try await coordinator.deleteRival(rival)
+
+        #expect(try await store.loadRivals().isEmpty)
+        #expect(coordinator.ledger(for: rival.id) == nil)
+    }
+
+    @Test("deleting rival with active local match clears match and rival")
+    @MainActor
+    func deleteRivalWithActiveLocalMatch() async throws {
+        let rival = Rival(displayName: "Dan")
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        )
+        let store = InMemoryLedgerStore(rivals: [rival], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+        try await coordinator.deleteRival(rival)
+
+        #expect(try await store.loadRivals().isEmpty)
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
+        #expect(coordinator.ledger(for: rival.id) == nil)
+    }
+
+    @Test("deleting rival with active Game Center match clears local match and rival")
+    @MainActor
+    func deleteRivalWithActiveGameCenterMatch() async throws {
+        let rival = Rival(displayName: "Dan", gameCenterPlayerID: "dan-gc")
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            gameCenterMatchID: "gc-match-1",
+            userPlayed: .black,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        )
+        let store = InMemoryLedgerStore(rivals: [rival], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+        try await coordinator.deleteRival(rival)
+
+        #expect(try await store.loadRivals().isEmpty)
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
+        #expect(coordinator.ledger(for: rival.id) == nil)
+    }
+
+    @Test("deleting rival with records requires explicit history deletion")
+    @MainActor
+    func deleteRivalWithRecordsRequiresConfirmation() async throws {
+        let rival = Rival(displayName: "Dan")
+        let record = completedRecord(rivalID: rival.id)
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 3))
+        )
+        let store = InMemoryLedgerStore(rivals: [rival], records: [record], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+        await #expect(throws: LedgerStoreError.rivalHasHistory) {
+            try await coordinator.deleteRival(rival)
+        }
+        #expect(try await store.loadRivals() == [rival])
+        #expect(try await store.loadMatchRecords(rivalID: rival.id) == [record])
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == active)
+
+        try await coordinator.deleteRival(rival, deletingRecords: true)
+
+        #expect(try await store.loadRivals().isEmpty)
+        #expect(try await store.loadMatchRecords(rivalID: rival.id).isEmpty)
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
+        #expect(coordinator.ledger(for: rival.id) == nil)
+    }
 }
 
 private final class CompletionDiceRoller: DiceRolling, @unchecked Sendable {
@@ -220,4 +303,17 @@ private final class CompletionDiceRoller: DiceRolling, @unchecked Sendable {
         index += 1
         return value
     }
+}
+
+private func completedRecord(rivalID: Rival.ID) -> MatchRecord {
+    MatchRecord(
+        rivalID: rivalID,
+        userPlayed: .white,
+        winner: .you,
+        userScore: 7,
+        rivalScore: 3,
+        targetScore: 7,
+        startedAt: Date(timeIntervalSince1970: 100),
+        completedAt: Date(timeIntervalSince1970: 200)
+    )
 }


### PR DESCRIPTION
Adds native trailing swipe delete actions to rivalry cards in both local and Game Center home screens. Deleting a rivalry now cascades through active local ledger state, can remove completed match records after confirmation, and attempts to forfeit/remove loaded Game Center matches first. Adds ledger-store APIs for deleting a rival's match records plus regression coverage for clean rivals, active local matches, active Game Center matches, and history deletion. Tested with `swift test` (133 tests).