### PR TITLE
Fix blue root screen icons

### DIFF
--- a/SheshBesh/Shared/AppLaunchConfiguration.swift
+++ b/SheshBesh/Shared/AppLaunchConfiguration.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SheshBeshGame
 import SwiftUI
 
@@ -9,6 +10,10 @@ public enum AppLaunchConfiguration {
     @MainActor
     public static func rootView(arguments: [String] = ProcessInfo.processInfo.arguments) -> RootView {
         #if DEBUG
+        if arguments.contains("-uiTestingRootLedger") {
+            return RootView(coordinator: seededRootLedgerCoordinator())
+        }
+
         if arguments.contains("-uiTesting") {
             let dice = scriptedDice(from: arguments)
             return RootView(
@@ -36,6 +41,24 @@ public enum AppLaunchConfiguration {
     }
 
     #if DEBUG
+    @MainActor
+    private static func seededRootLedgerCoordinator() -> LedgerCoordinator {
+        let rival = Rival(
+            id: UUID(uuidString: "7C48FB94-F61B-4D71-BF7F-A181713381B4")!,
+            displayName: "Local AI",
+            createdAt: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+        let activeMatch = ActiveMatch(
+            id: UUID(uuidString: "C74A6D96-5DB9-4774-8EA7-9192F341955E")!,
+            rivalID: rival.id,
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 1)),
+            startedAt: Date(timeIntervalSinceReferenceDate: 800_000_100),
+            lastUpdatedAt: Date(timeIntervalSinceReferenceDate: 800_000_200)
+        )
+        return LedgerCoordinator(store: InMemoryLedgerStore(rivals: [rival], activeMatches: [activeMatch]))
+    }
+
     private static func scriptedDice(from arguments: [String]) -> [Int] {
         guard
             let diceFlagIndex = arguments.firstIndex(of: "-uiTestDice"),

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -255,7 +255,11 @@ struct RemoveAllMatchesButton: View {
 
     var body: some View {
         Button(role: .destructive, action: action) {
-            Label("Remove All Matches", systemImage: "trash")
+            ThemedButtonLabel(
+                title: "Remove All Matches",
+                systemImage: "trash",
+                foregroundStyle: LedgerTheme.rust
+            )
                 .font(LedgerTheme.uiFont(size: 15, weight: .semibold))
                 .lineLimit(1)
                 .minimumScaleFactor(0.82)
@@ -280,7 +284,11 @@ struct RivalryLaunchActions: View {
     var body: some View {
         HStack(spacing: 10) {
             Button(action: onPrimary) {
-                Label(primaryTitle, systemImage: primarySystemImage)
+                ThemedButtonLabel(
+                    title: primaryTitle,
+                    systemImage: primarySystemImage,
+                    foregroundStyle: .white
+                )
                     .font(LedgerTheme.uiFont(size: 15, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.82)
@@ -292,7 +300,11 @@ struct RivalryLaunchActions: View {
             .accessibilityIdentifier("home-new-ai-rival")
 
             Button(action: onSecondary) {
-                Label(secondaryTitle, systemImage: secondarySystemImage)
+                ThemedButtonLabel(
+                    title: secondaryTitle,
+                    systemImage: secondarySystemImage,
+                    foregroundStyle: LedgerTheme.coffee
+                )
                     .font(LedgerTheme.uiFont(size: 15, weight: .semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.82)
@@ -392,7 +404,11 @@ private struct RivalryCard: View {
 
             if ledger.activeMatch == nil {
                 Button(action: onStart) {
-                    Label(startTitle, systemImage: startSystemImage)
+                    ThemedButtonLabel(
+                        title: startTitle,
+                        systemImage: startSystemImage,
+                        foregroundStyle: .white
+                    )
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
@@ -400,7 +416,11 @@ private struct RivalryCard: View {
                 .accessibilityIdentifier("start-match-\(ledger.rival.id.uuidString)")
             } else {
                 Button(action: onResume) {
-                    Label(resumeTitle, systemImage: resumeSystemImage)
+                    ThemedButtonLabel(
+                        title: resumeTitle,
+                        systemImage: resumeSystemImage,
+                        foregroundStyle: .white
+                    )
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
@@ -473,6 +493,21 @@ private struct MetricPill: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 7)
         .background(LedgerTheme.linen, in: RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+private struct ThemedButtonLabel: View {
+    let title: String
+    let systemImage: String
+    let foregroundStyle: Color
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: systemImage)
+                .foregroundStyle(foregroundStyle)
+            Text(title)
+                .foregroundStyle(foregroundStyle)
+        }
     }
 }
 

--- a/SheshBeshUITests/SheshBeshUITests.swift
+++ b/SheshBeshUITests/SheshBeshUITests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 
 final class SheshBeshUITests: XCTestCase {
     override func setUpWithError() throws {
@@ -66,6 +67,39 @@ final class SheshBeshUITests: XCTestCase {
     }
 
     @MainActor
+    func testRootRivalryButtonsDoNotRenderSystemBlueIcons() throws {
+        let app = rootLedgerApp()
+        app.launch()
+
+        let aiButton = app.buttons["home-new-ai-rival"]
+        let inviteButton = app.buttons["home-new-game-center-rival"]
+        let removeAllButton = app.buttons["home-remove-all-matches"]
+        let resumeButton = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH %@", "resume-match-")
+        ).firstMatch
+
+        XCTAssertTrue(aiButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(inviteButton.exists)
+        XCTAssertTrue(removeAllButton.waitForExistence(timeout: 2))
+        XCTAssertTrue(resumeButton.waitForExistence(timeout: 2))
+
+        let screenshot = XCUIScreen.main.screenshot()
+        let blueControls = [
+            ("Practice vs AI", aiButton),
+            ("Invite Friend", inviteButton),
+            ("Remove All Matches", removeAllButton),
+            ("Resume match", resumeButton),
+        ].filter { _, control in
+            screenshotContainsSystemBlue(in: control.frame, screenshot: screenshot, appFrame: app.frame)
+        }
+
+        XCTAssertTrue(
+            blueControls.isEmpty,
+            "Expected themed Rivalries root controls to avoid system-blue pixels, but found blue in: \(blueControls.map(\.0).joined(separator: ", "))"
+        )
+    }
+
+    @MainActor
     private func configuredApp() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments = [
@@ -73,6 +107,13 @@ final class SheshBeshUITests: XCTestCase {
             "-uiTestDice",
             "6,1,6,1",
         ]
+        return app
+    }
+
+    @MainActor
+    private func rootLedgerApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uiTestingRootLedger"]
         return app
     }
 
@@ -87,5 +128,100 @@ final class SheshBeshUITests: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+    @MainActor
+    private func screenshotContainsSystemBlue(
+        in frame: CGRect,
+        screenshot: XCUIScreenshot,
+        appFrame: CGRect
+    ) -> Bool {
+        guard
+            let image = UIImage(data: screenshot.pngRepresentation),
+            let cgImage = image.cgImage,
+            let dataProvider = cgImage.dataProvider,
+            let data = dataProvider.data,
+            let bytes = CFDataGetBytePtr(data)
+        else {
+            XCTFail("Could not inspect screenshot pixels")
+            return false
+        }
+
+        let screenFrame = appFrame.isEmpty ? UIScreen.main.bounds : appFrame
+        let scaleX = CGFloat(cgImage.width) / max(screenFrame.width, 1)
+        let scaleY = CGFloat(cgImage.height) / max(screenFrame.height, 1)
+        let pixelFrame = frame
+            .insetBy(dx: 2, dy: 2)
+            .applying(CGAffineTransform(scaleX: scaleX, y: scaleY))
+            .integral
+            .intersection(CGRect(x: 0, y: 0, width: cgImage.width, height: cgImage.height))
+
+        guard !pixelFrame.isNull, !pixelFrame.isEmpty else { return false }
+
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        guard bytesPerPixel >= 4 else {
+            XCTFail("Unexpected screenshot pixel format")
+            return false
+        }
+
+        let minX = max(Int(pixelFrame.minX), 0)
+        let maxX = min(Int(pixelFrame.maxX), cgImage.width)
+        let minY = max(Int(pixelFrame.minY), 0)
+        let maxY = min(Int(pixelFrame.maxY), cgImage.height)
+        let stride = 2
+
+        for y in Swift.stride(from: minY, to: maxY, by: stride) {
+            for x in Swift.stride(from: minX, to: maxX, by: stride) {
+                let offset = y * cgImage.bytesPerRow + x * bytesPerPixel
+                let (red, green, blue) = rgbComponents(
+                    bytes: bytes,
+                    offset: offset,
+                    bitmapInfo: cgImage.bitmapInfo
+                )
+
+                if isSystemBlue(red: red, green: green, blue: blue) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    private func rgbComponents(
+        bytes: UnsafePointer<UInt8>,
+        offset: Int,
+        bitmapInfo: CGBitmapInfo
+    ) -> (red: UInt8, green: UInt8, blue: UInt8) {
+        let alphaInfo = CGImageAlphaInfo(rawValue: bitmapInfo.rawValue & CGBitmapInfo.alphaInfoMask.rawValue)
+        let byteOrder = bitmapInfo.intersection(CGBitmapInfo.byteOrderMask)
+        switch byteOrder {
+        case .byteOrder32Little:
+            switch alphaInfo {
+            case .premultipliedFirst, .first, .noneSkipFirst:
+                return (bytes[offset + 2], bytes[offset + 1], bytes[offset])
+            case .premultipliedLast, .last, .noneSkipLast:
+                return (bytes[offset + 3], bytes[offset + 2], bytes[offset + 1])
+            default:
+                return (bytes[offset + 2], bytes[offset + 1], bytes[offset])
+            }
+        case .byteOrder32Big:
+            switch alphaInfo {
+            case .premultipliedFirst, .first, .noneSkipFirst:
+                return (bytes[offset + 1], bytes[offset + 2], bytes[offset + 3])
+            default:
+                return (bytes[offset], bytes[offset + 1], bytes[offset + 2])
+            }
+        default:
+            return (bytes[offset], bytes[offset + 1], bytes[offset + 2])
+        }
+    }
+
+    private func isSystemBlue(red: UInt8, green: UInt8, blue: UInt8) -> Bool {
+        blue > 150 &&
+            green > 80 &&
+            red < 100 &&
+            blue > red + 70 &&
+            blue > green + 25
     }
 }


### PR DESCRIPTION
## Summary
Fixes the Rivalries root screen so themed button icons no longer inherit system blue inside SwiftUI List rows. Adds a DEBUG-only seeded root launch mode and a UI regression test that screenshots the root controls and fails if system-blue pixels appear in the affected buttons.

## Tests
- ./scripts/test-ui.sh