### PR TITLE
Replace "YOU vs" with opponent-type icon in rivalry rows

### DIFF
--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -374,11 +374,18 @@ private struct RivalryCard: View {
         VStack(alignment: .leading, spacing: isHero ? 16 : 12) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("YOU vs \(ledger.rival.displayName.uppercased())")
-                        .font(LedgerTheme.displayFont(size: isHero ? 28 : 22, weight: .bold))
-                        .foregroundStyle(LedgerTheme.ink)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.68)
+                    HStack(spacing: 8) {
+                        Image(systemName: ledger.rival.gameCenterPlayerID == nil ? "cpu" : "person.crop.circle.fill")
+                            .font(LedgerTheme.displayFont(size: isHero ? 28 : 22, weight: .bold))
+                            .foregroundStyle(LedgerTheme.mutedInk)
+                            .accessibilityHidden(true)
+
+                        Text(ledger.rival.displayName.uppercased())
+                            .font(LedgerTheme.displayFont(size: isHero ? 28 : 22, weight: .bold))
+                            .foregroundStyle(LedgerTheme.ink)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.68)
+                    }
 
                     Text(statusLine)
                         .font(LedgerTheme.uiFont(size: 14, weight: .semibold))


### PR DESCRIPTION
## Summary
- Drops the redundant "YOU vs" prefix from every rivalry row on the home screen — every row was always "you", so the leading word added no signal.
- Each row now leads with an SF Symbol indicating opponent type (`cpu` for AI, `person.crop.circle.fill` for human Game Center rivals) followed by the opponent's name. The in-match `BoardView` header is intentionally unchanged.

## Test plan
- [ ] Build and launch in iOS Simulator
- [ ] Confirm AI rivalry shows `cpu` icon + `LOCAL AI`
- [ ] Confirm Game Center rivalry shows `person.crop.circle.fill` + opponent name
- [ ] Verify hero (28pt) and standard (22pt) rows both render cleanly
- [ ] Verify long names still scale via `minimumScaleFactor(0.68)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)