### PR TITLE
Add animated launch splash

### DIFF
--- a/SheshBesh.xcodeproj/project.pbxproj
+++ b/SheshBesh.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		AF3000000000000000000017 /* LedgerAggregation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3000000000000000000018 /* LedgerAggregation.swift */; };
 		AF4000000000000000000001 /* GameCenterEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4000000000000000000002 /* GameCenterEnvelope.swift */; };
 		AF4000000000000000000003 /* GameCenterSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4000000000000000000004 /* GameCenterSupport.swift */; };
+		AF6000000000000000000001 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF6000000000000000000002 /* SplashView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		AF4000000000000000000002 /* GameCenterEnvelope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCenterEnvelope.swift; sourceTree = "<group>"; };
 		AF4000000000000000000004 /* GameCenterSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameCenterSupport.swift; sourceTree = "<group>"; };
 		AF4000000000000000000005 /* SheshBesh.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SheshBesh.entitlements; sourceTree = "<group>"; };
+		AF6000000000000000000002 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +181,7 @@
 				AF1000000000000000000006 /* MatchViewModel.swift */,
 				AF3000000000000000000006 /* MatchEndSheet.swift */,
 				AF1000000000000000000004 /* RootView.swift */,
+				AF6000000000000000000002 /* SplashView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -384,6 +387,7 @@
 				AF1000000000000000000005 /* MatchViewModel.swift in Sources */,
 				AF3000000000000000000005 /* MatchEndSheet.swift in Sources */,
 				AF1000000000000000000003 /* RootView.swift in Sources */,
+				AF6000000000000000000001 /* SplashView.swift in Sources */,
 				AF300000000000000000000D /* ActiveMatch.swift in Sources */,
 				AF3000000000000000000013 /* InMemoryLedgerStore.swift in Sources */,
 				AF3000000000000000000015 /* JSONLedgerStore.swift in Sources */,
@@ -529,11 +533,11 @@
 				DEVELOPMENT_TEAM = 8DDY9Z9MX6;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SheshBesh/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Shesh Besh";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -560,11 +564,11 @@
 				DEVELOPMENT_TEAM = 8DDY9Z9MX6;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SheshBesh/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "Shesh Besh";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/SheshBesh/App/SheshBeshMain.swift
+++ b/SheshBesh/App/SheshBeshMain.swift
@@ -8,7 +8,32 @@ import SheshBeshApp
 struct SheshBeshMain: App {
     var body: some Scene {
         WindowGroup {
-            AppLaunchConfiguration.rootView()
+            RootContainer()
+        }
+    }
+}
+
+private struct RootContainer: View {
+    @State private var showSplash: Bool
+    private let root: RootView
+
+    init(arguments: [String] = ProcessInfo.processInfo.arguments) {
+        self.root = AppLaunchConfiguration.rootView(arguments: arguments)
+        let isUITesting = arguments.contains("-uiTesting") || arguments.contains("-uiTestingRootLedger")
+        _showSplash = State(initialValue: !isUITesting)
+    }
+
+    var body: some View {
+        ZStack {
+            root
+            if showSplash {
+                SplashView(onFinished: {
+                    withAnimation(.easeInOut(duration: 0.35)) {
+                        showSplash = false
+                    }
+                })
+                .transition(.opacity)
+            }
         }
     }
 }

--- a/SheshBesh/Assets.xcassets/LaunchBackground.colorset/Contents.json
+++ b/SheshBesh/Assets.xcassets/LaunchBackground.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.831",
+          "green" : "0.902",
+          "red" : "0.937"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SheshBesh/Info.plist
+++ b/SheshBesh/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UIColorName</key>
+		<string>LaunchBackground</string>
+	</dict>
+</dict>
+</plist>

--- a/SheshBesh/Shared/SplashView.swift
+++ b/SheshBesh/Shared/SplashView.swift
@@ -50,22 +50,26 @@ public struct SplashView: View {
     }
 
     private func runIntro() async {
-        withAnimation(.spring(response: 0.55, dampingFraction: 0.72)) {
-            diceLanded = true
+        do {
+            withAnimation(.spring(response: 0.55, dampingFraction: 0.72)) {
+                diceLanded = true
+            }
+            try await Task.sleep(for: .milliseconds(540))
+            withAnimation(.spring(response: 0.22, dampingFraction: 0.5)) {
+                pulse = true
+            }
+            try await Task.sleep(for: .milliseconds(140))
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.65)) {
+                pulse = false
+            }
+            withAnimation(.easeOut(duration: 0.45)) {
+                titleVisible = true
+            }
+            try await Task.sleep(for: .milliseconds(720))
+            onFinished()
+        } catch {
+            return
         }
-        try? await Task.sleep(for: .milliseconds(540))
-        withAnimation(.spring(response: 0.22, dampingFraction: 0.5)) {
-            pulse = true
-        }
-        try? await Task.sleep(for: .milliseconds(140))
-        withAnimation(.spring(response: 0.3, dampingFraction: 0.65)) {
-            pulse = false
-        }
-        withAnimation(.easeOut(duration: 0.45)) {
-            titleVisible = true
-        }
-        try? await Task.sleep(for: .milliseconds(720))
-        onFinished()
     }
 }
 

--- a/SheshBesh/Shared/SplashView.swift
+++ b/SheshBesh/Shared/SplashView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+public struct SplashView: View {
+    private let onFinished: () -> Void
+
+    @State private var diceLanded = false
+    @State private var pulse = false
+    @State private var titleVisible = false
+
+    public init(onFinished: @escaping () -> Void) {
+        self.onFinished = onFinished
+    }
+
+    public var body: some View {
+        ZStack {
+            LinenBrass.linen
+                .ignoresSafeArea()
+
+            RadialGradient(
+                colors: [LinenBrass.linen, LinenBrass.linenDeep.opacity(0.55)],
+                center: .center,
+                startRadius: 80,
+                endRadius: 460
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 36) {
+                HStack(spacing: 22) {
+                    DieView(value: 6, face: LinenBrass.cream, pip: LinenBrass.rust)
+                        .rotationEffect(.degrees(diceLanded ? -7 : -120))
+                        .offset(x: diceLanded ? 0 : -260, y: diceLanded ? 0 : -140)
+                        .scaleEffect(diceLanded ? (pulse ? 1.07 : 1.0) : 0.4)
+                        .opacity(diceLanded ? 1 : 0)
+                    DieView(value: 5, face: LinenBrass.rust, pip: LinenBrass.cream)
+                        .rotationEffect(.degrees(diceLanded ? 8 : 120))
+                        .offset(x: diceLanded ? 0 : 260, y: diceLanded ? 0 : -140)
+                        .scaleEffect(diceLanded ? (pulse ? 1.07 : 1.0) : 0.4)
+                        .opacity(diceLanded ? 1 : 0)
+                }
+
+                Text("Shesh Besh")
+                    .font(.system(size: 44, weight: .semibold, design: .serif))
+                    .foregroundStyle(LinenBrass.ink)
+                    .tracking(1.5)
+                    .opacity(titleVisible ? 1 : 0)
+                    .offset(y: titleVisible ? 0 : 12)
+            }
+        }
+        .task { await runIntro() }
+    }
+
+    private func runIntro() async {
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.72)) {
+            diceLanded = true
+        }
+        try? await Task.sleep(for: .milliseconds(540))
+        withAnimation(.spring(response: 0.22, dampingFraction: 0.5)) {
+            pulse = true
+        }
+        try? await Task.sleep(for: .milliseconds(140))
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.65)) {
+            pulse = false
+        }
+        withAnimation(.easeOut(duration: 0.45)) {
+            titleVisible = true
+        }
+        try? await Task.sleep(for: .milliseconds(720))
+        onFinished()
+    }
+}
+
+private struct DieView: View {
+    let value: Int
+    let face: Color
+    let pip: Color
+
+    private static let dieSize: CGFloat = 96
+    private static let cornerRadius: CGFloat = 20
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                .fill(face)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                        .stroke(LinenBrass.brass.opacity(0.6), lineWidth: 1.2)
+                )
+                .shadow(color: LinenBrass.coffee.opacity(0.28), radius: 12, x: 0, y: 8)
+
+            PipGrid(value: value, color: pip)
+                .padding(Self.dieSize * 0.18)
+        }
+        .frame(width: Self.dieSize, height: Self.dieSize)
+    }
+}
+
+private struct PipGrid: View {
+    let value: Int
+    let color: Color
+
+    var body: some View {
+        GeometryReader { proxy in
+            let positions = pipPositions(in: proxy.size)
+            let pipDiameter = proxy.size.width * 0.2
+            ForEach(0..<positions.count, id: \.self) { idx in
+                Circle()
+                    .fill(color)
+                    .frame(width: pipDiameter, height: pipDiameter)
+                    .position(positions[idx])
+            }
+        }
+    }
+
+    private func pipPositions(in size: CGSize) -> [CGPoint] {
+        let w = size.width
+        let h = size.height
+        let lx = w * 0.2
+        let cx = w * 0.5
+        let rx = w * 0.8
+        let ty = h * 0.2
+        let my = h * 0.5
+        let by = h * 0.8
+
+        switch value {
+        case 1:
+            return [CGPoint(x: cx, y: my)]
+        case 2:
+            return [CGPoint(x: lx, y: ty), CGPoint(x: rx, y: by)]
+        case 3:
+            return [CGPoint(x: lx, y: ty), CGPoint(x: cx, y: my), CGPoint(x: rx, y: by)]
+        case 4:
+            return [
+                CGPoint(x: lx, y: ty), CGPoint(x: rx, y: ty),
+                CGPoint(x: lx, y: by), CGPoint(x: rx, y: by)
+            ]
+        case 5:
+            return [
+                CGPoint(x: lx, y: ty), CGPoint(x: rx, y: ty),
+                CGPoint(x: cx, y: my),
+                CGPoint(x: lx, y: by), CGPoint(x: rx, y: by)
+            ]
+        case 6:
+            return [
+                CGPoint(x: lx, y: ty), CGPoint(x: rx, y: ty),
+                CGPoint(x: lx, y: my), CGPoint(x: rx, y: my),
+                CGPoint(x: lx, y: by), CGPoint(x: rx, y: by)
+            ]
+        default:
+            return []
+        }
+    }
+}
+
+private enum LinenBrass {
+    static let linen = Color(red: 0.937, green: 0.902, blue: 0.831)
+    static let linenDeep = Color(red: 0.871, green: 0.785, blue: 0.647)
+    static let cream = Color(red: 0.929, green: 0.886, blue: 0.800)
+    static let coffee = Color(red: 0.420, green: 0.290, blue: 0.180)
+    static let rust = Color(red: 0.659, green: 0.314, blue: 0.165)
+    static let brass = Color(red: 0.722, green: 0.537, blue: 0.227)
+    static let ink = Color(red: 0.126, green: 0.075, blue: 0.035)
+}
+
+#if DEBUG
+#Preview {
+    SplashView(onFinished: {})
+}
+#endif


### PR DESCRIPTION
## Summary
- Adds a themed iOS launch screen (linen `LaunchBackground` color asset wired through a new `SheshBesh/Info.plist`) so cold launches no longer flash a white frame.
- Adds `SplashView` — a SwiftUI splash that tumbles two dice in (cream + rust, 6 / 5 face), then fades up the "Shesh Besh" serif title — and a `RootContainer` wrapper in `SheshBeshMain` that crossfades from splash to `RootView` after ~1.4s.
- Skips the splash automatically when launched with `-uiTesting` / `-uiTestingRootLedger` so existing UI tests run unchanged.

## Test plan
- [ ] Cold launch on iOS Simulator: linen flash → splash with dice tumbling in and title fading up → home (no white frame).
- [ ] Background/foreground cycle: splash does not replay.
- [ ] `xcodebuild -scheme SheshBesh -destination 'platform=iOS Simulator,name=iPhone 17' test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)