### PR TITLE
Fix Game Center sign-in button color

### DIFF
--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -747,12 +747,17 @@ public struct GameCenterHomeView: View {
                 Button {
                     session.retry()
                 } label: {
-                    Label(authButtonTitle, systemImage: "person.crop.circle.badge.checkmark")
+                    ThemedButtonLabel(
+                        title: authButtonTitle,
+                        systemImage: "person.crop.circle.badge.checkmark",
+                        foregroundStyle: .white
+                    )
                         .frame(maxWidth: .infinity)
                 }
                 .buttonStyle(.borderedProminent)
                 .tint(LedgerTheme.rust)
                 .disabled(session.authState == .authenticating)
+                .accessibilityIdentifier("game-center-sign-in")
             }
         }
         .padding(18)

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -496,7 +496,7 @@ private struct MetricPill: View {
     }
 }
 
-private struct ThemedButtonLabel: View {
+struct ThemedButtonLabel: View {
     let title: String
     let systemImage: String
     let foregroundStyle: Color

--- a/SheshBeshUITests/SheshBeshUITests.swift
+++ b/SheshBeshUITests/SheshBeshUITests.swift
@@ -74,6 +74,7 @@ final class SheshBeshUITests: XCTestCase {
         let aiButton = app.buttons["home-new-ai-rival"]
         let inviteButton = app.buttons["home-new-game-center-rival"]
         let removeAllButton = app.buttons["home-remove-all-matches"]
+        let gameCenterSignInButton = app.buttons["game-center-sign-in"]
         let resumeButton = app.buttons.matching(
             NSPredicate(format: "identifier BEGINSWITH %@", "resume-match-")
         ).firstMatch
@@ -81,6 +82,7 @@ final class SheshBeshUITests: XCTestCase {
         XCTAssertTrue(aiButton.waitForExistence(timeout: 5))
         XCTAssertTrue(inviteButton.exists)
         XCTAssertTrue(removeAllButton.waitForExistence(timeout: 2))
+        XCTAssertTrue(gameCenterSignInButton.waitForExistence(timeout: 2))
         XCTAssertTrue(resumeButton.waitForExistence(timeout: 2))
 
         let screenshot = XCUIScreen.main.screenshot()
@@ -88,6 +90,7 @@ final class SheshBeshUITests: XCTestCase {
             ("Practice vs AI", aiButton),
             ("Invite Friend", inviteButton),
             ("Remove All Matches", removeAllButton),
+            ("Game Center sign in", gameCenterSignInButton),
             ("Resume match", resumeButton),
         ].filter { _, control in
             screenshotContainsSystemBlue(in: control.frame, screenshot: screenshot, appFrame: app.frame)


### PR DESCRIPTION
## Summary
- Reuses the themed button label for the Game Center sign-in button so the icon/text no longer render with system blue.
- Adds a stable accessibility identifier and includes the sign-in button in the existing system-blue pixel regression test.

## Tests
- ./scripts/test-ui.sh
- ./scripts/test.sh