### PR TITLE
Add Easy/Medium/Hard AI difficulty levels for Practice vs AI

### DIFF
--- a/SheshBesh/Shared/AppLaunchConfiguration.swift
+++ b/SheshBesh/Shared/AppLaunchConfiguration.swift
@@ -45,7 +45,7 @@ public enum AppLaunchConfiguration {
     private static func seededRootLedgerCoordinator() -> LedgerCoordinator {
         let rival = Rival(
             id: UUID(uuidString: "7C48FB94-F61B-4D71-BF7F-A181713381B4")!,
-            displayName: "Local AI",
+            displayName: AIDifficulty.medium.rivalDisplayName,
             createdAt: Date(timeIntervalSinceReferenceDate: 800_000_000)
         )
         let activeMatch = ActiveMatch(

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -896,12 +896,12 @@ public struct GameCenterHomeView: View {
         }
     }
 
-    private func startAIRivalry() {
+    private func startAIRivalry(difficulty: AIDifficulty) {
         guard !isWorking else { return }
         isWorking = true
         Task {
             do {
-                onOpenLocalMatch(try await ledgerCoordinator.startAIRivalry())
+                onOpenLocalMatch(try await ledgerCoordinator.startAIRivalry(difficulty: difficulty))
             } catch {
                 localError = error.localizedDescription
             }

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -173,12 +173,12 @@ public struct HomeView: View {
         }
     }
 
-    private func startAIRivalry() {
+    private func startAIRivalry(difficulty: AIDifficulty) {
         guard !isWorking else { return }
         isWorking = true
         Task {
             do {
-                onOpenMatch(try await coordinator.startAIRivalry())
+                onOpenMatch(try await coordinator.startAIRivalry(difficulty: difficulty))
             } catch {
                 localError = error.localizedDescription
             }
@@ -278,12 +278,19 @@ struct RivalryLaunchActions: View {
     let primarySystemImage: String
     let secondaryTitle: String
     let secondarySystemImage: String
-    let onPrimary: () -> Void
+    let onPrimary: (AIDifficulty) -> Void
     let onSecondary: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
-            Button(action: onPrimary) {
+            Menu {
+                ForEach(AIDifficulty.allCases, id: \.self) { difficulty in
+                    Button(difficulty.menuLabel) {
+                        onPrimary(difficulty)
+                    }
+                    .accessibilityIdentifier("home-new-ai-rival-\(difficulty.rawValue)")
+                }
+            } label: {
                 ThemedButtonLabel(
                     title: primaryTitle,
                     systemImage: primarySystemImage,

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -9,7 +9,6 @@ import SheshBeshLedger
 @MainActor
 @Observable
 public final class LedgerCoordinator {
-    private static let quickAIRivalDisplayName = "Local AI"
     private static let quickAIMatchConfig = MatchConfig.tournament(targetScore: 1)
 
     @ObservationIgnored private let store: any LedgerStore
@@ -112,16 +111,16 @@ public final class LedgerCoordinator {
         return rival
     }
 
-    public func startAIRivalry() async throws -> ActiveMatch {
+    public func startAIRivalry(difficulty: AIDifficulty) async throws -> ActiveMatch {
         await refresh()
 
         let rival: Rival
         if let existingRival = ledgers
             .map(\.rival)
-            .first(where: Self.isQuickAIRival) {
+            .first(where: { Self.isQuickAIRival($0, difficulty: difficulty) }) {
             rival = existingRival
         } else {
-            rival = Rival(displayName: Self.quickAIRivalDisplayName)
+            rival = Rival(displayName: difficulty.rivalDisplayName)
             try await store.upsertRival(rival)
             await refresh()
         }
@@ -166,8 +165,8 @@ public final class LedgerCoordinator {
         lastErrorMessage = nil
     }
 
-    private static func isQuickAIRival(_ rival: Rival) -> Bool {
-        rival.gameCenterPlayerID == nil && rival.displayName == quickAIRivalDisplayName
+    private static func isQuickAIRival(_ rival: Rival, difficulty: AIDifficulty) -> Bool {
+        rival.gameCenterPlayerID == nil && rival.displayName == difficulty.rivalDisplayName
     }
 
     private static func sortLedgers(_ lhs: RivalLedger, _ rhs: RivalLedger) -> Bool {

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -76,7 +76,6 @@ public final class MatchViewModel {
     ) {
         let initialState = initialState ?? MatchEngine.newMatch(config: config)
         let initialLegalActions = engine.legalActions(in: initialState)
-        let resolvedOpponent = opponentController ?? LocalAIOpponent(difficulty: aiDifficulty)
 
         self.engine = engine
         self.state = initialState
@@ -85,7 +84,7 @@ public final class MatchViewModel {
         self.opponentName = opponentName
         self.isOpponentAutoplayEnabled = isOpponentAutoplayEnabled
         self.activeMatchID = activeMatchID
-        self.opponentController = resolvedOpponent
+        self.opponentController = opponentController ?? LocalAIOpponent(difficulty: aiDifficulty)
         self.opponentDelay = opponentDelay
         self.isOpponentThinking = false
         self.turnNotice = nil

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -3,6 +3,32 @@ import Observation
 import SheshBeshGame
 import SwiftUI
 
+public enum AIDifficulty: String, CaseIterable, Codable, Sendable {
+    case easy
+    case medium
+    case hard
+
+    public var rivalDisplayName: String {
+        switch self {
+        case .easy: "Easy AI"
+        case .medium: "Medium AI"
+        case .hard: "Hard AI"
+        }
+    }
+
+    public var menuLabel: String {
+        switch self {
+        case .easy: "Easy"
+        case .medium: "Medium"
+        case .hard: "Hard"
+        }
+    }
+
+    public static func fromRivalDisplayName(_ name: String) -> AIDifficulty? {
+        AIDifficulty.allCases.first { $0.rivalDisplayName == name }
+    }
+}
+
 @MainActor
 @Observable
 public final class MatchViewModel {
@@ -37,11 +63,12 @@ public final class MatchViewModel {
         engine: MatchEngine = MatchEngine(),
         config: MatchConfig = .tournament(targetScore: 1),
         localPlayer: Player = .white,
-        opponentName: String = "Local AI",
+        opponentName: String = "Medium AI",
         activeMatchID: UUID = UUID(),
         initialState: MatchState? = nil,
         isOpponentAutoplayEnabled: Bool = true,
-        opponentController: LocalAIOpponent = LocalAIOpponent(),
+        aiDifficulty: AIDifficulty = .medium,
+        opponentController: LocalAIOpponent? = nil,
         opponentDelay: @escaping @Sendable () async -> Void = {
             let nanoseconds = UInt64(Double.random(in: 0.8...1.2) * 1_000_000_000)
             try? await Task.sleep(nanoseconds: nanoseconds)
@@ -49,6 +76,7 @@ public final class MatchViewModel {
     ) {
         let initialState = initialState ?? MatchEngine.newMatch(config: config)
         let initialLegalActions = engine.legalActions(in: initialState)
+        let resolvedOpponent = opponentController ?? LocalAIOpponent(difficulty: aiDifficulty)
 
         self.engine = engine
         self.state = initialState
@@ -57,7 +85,7 @@ public final class MatchViewModel {
         self.opponentName = opponentName
         self.isOpponentAutoplayEnabled = isOpponentAutoplayEnabled
         self.activeMatchID = activeMatchID
-        self.opponentController = opponentController
+        self.opponentController = resolvedOpponent
         self.opponentDelay = opponentDelay
         self.isOpponentThinking = false
         self.turnNotice = nil
@@ -507,11 +535,22 @@ public final class MatchViewModel {
 }
 
 public struct LocalAIOpponent: Sendable {
+    private static let hitBonus = 50
+    private static let pointBonus = 15
+    private static let innerPointBonus = 25
+    private static let blotPenalty = 20
+    private static let homeBlotPenalty = 10
+
+    public let difficulty: AIDifficulty
     private let randomIndex: @Sendable (Int) -> Int
 
-    public init(randomIndex: @escaping @Sendable (Int) -> Int = { upperBound in
-        Int.random(in: 0..<upperBound)
-    }) {
+    public init(
+        difficulty: AIDifficulty = .medium,
+        randomIndex: @escaping @Sendable (Int) -> Int = { upperBound in
+            Int.random(in: 0..<upperBound)
+        }
+    ) {
+        self.difficulty = difficulty
         self.randomIndex = randomIndex
     }
 
@@ -533,7 +572,7 @@ public struct LocalAIOpponent: Sendable {
         case .roll:
             return .rollDice(opponent)
         case .move:
-            return selectPipBiasedMove(
+            return selectMove(
                 for: opponent,
                 in: state,
                 legalActions: legalActions,
@@ -555,20 +594,50 @@ public struct LocalAIOpponent: Sendable {
         }
     }
 
+    public func selectMove(
+        for player: Player,
+        in state: MatchState,
+        legalActions: [MatchAction],
+        pipCounts: [Player: Int]
+    ) -> Move? {
+        let moves = legalMoves(for: player, in: legalActions)
+        guard !moves.isEmpty else { return nil }
+
+        switch difficulty {
+        case .easy:
+            return moves[clampedRandomIndex(upperBound: moves.count)]
+        case .medium:
+            return selectPipBiasedMove(
+                for: player,
+                moves: moves,
+                pipCounts: pipCounts
+            )
+        case .hard:
+            return selectHeuristicMove(
+                for: player,
+                in: state,
+                moves: moves,
+                pipCounts: pipCounts
+            )
+        }
+    }
+
     public func selectPipBiasedMove(
         for player: Player,
         in state: MatchState,
         legalActions: [MatchAction],
         pipCounts: [Player: Int]
     ) -> Move? {
-        let moves = legalActions.compactMap { action -> Move? in
-            if case .move(let move) = action, move.player == player {
-                return move
-            }
-            return nil
-        }
+        let moves = legalMoves(for: player, in: legalActions)
         guard !moves.isEmpty else { return nil }
+        return selectPipBiasedMove(for: player, moves: moves, pipCounts: pipCounts)
+    }
 
+    private func selectPipBiasedMove(
+        for player: Player,
+        moves: [Move],
+        pipCounts: [Player: Int]
+    ) -> Move? {
         let currentPips = pipCounts[player, default: 0]
         let rankedMoves = moves.map { move in
             (move: move, projectedPips: projectedPipCount(currentPips, after: move))
@@ -576,6 +645,72 @@ public struct LocalAIOpponent: Sendable {
         guard let bestPips = rankedMoves.map(\.projectedPips).min() else { return nil }
         let bestMoves = rankedMoves.filter { $0.projectedPips == bestPips }.map(\.move)
         return bestMoves[clampedRandomIndex(upperBound: bestMoves.count)]
+    }
+
+    private func selectHeuristicMove(
+        for player: Player,
+        in state: MatchState,
+        moves: [Move],
+        pipCounts: [Player: Int]
+    ) -> Move? {
+        let currentPips = pipCounts[player, default: 0]
+        let board = state.game.board
+        let scored = moves.map { move -> (move: Move, score: Int) in
+            let projected = projectedPipCount(currentPips, after: move)
+            var score = currentPips - projected
+            score += hitScore(for: move, on: board, player: player)
+            score += pointMakingScore(for: move, on: board, player: player)
+            score -= sourceBlotPenalty(for: move, on: board, player: player)
+            score -= destinationBlotPenalty(for: move, on: board, player: player)
+            return (move, score)
+        }
+        guard let bestScore = scored.map(\.score).max() else { return nil }
+        let bestMoves = scored.filter { $0.score == bestScore }.map(\.move)
+        return bestMoves[clampedRandomIndex(upperBound: bestMoves.count)]
+    }
+
+    private func legalMoves(for player: Player, in legalActions: [MatchAction]) -> [Move] {
+        legalActions.compactMap { action -> Move? in
+            if case .move(let move) = action, move.player == player {
+                return move
+            }
+            return nil
+        }
+    }
+
+    private func hitScore(for move: Move, on board: Board, player: Player) -> Int {
+        guard case .point(let dest) = move.destination else { return 0 }
+        let state = board.point(dest)
+        return state.owner == player.opponent && state.count == 1 ? Self.hitBonus : 0
+    }
+
+    private func pointMakingScore(for move: Move, on board: Board, player: Player) -> Int {
+        guard case .point(let dest) = move.destination else { return 0 }
+        let state = board.point(dest)
+        guard state.owner == player, state.count == 1 else { return 0 }
+        return player.homeBoard.contains(dest.rawValue) ? Self.innerPointBonus : Self.pointBonus
+    }
+
+    private func sourceBlotPenalty(for move: Move, on board: Board, player: Player) -> Int {
+        guard case .point(let src) = move.source else { return 0 }
+        let state = board.point(src)
+        guard state.owner == player, state.count == 2 else { return 0 }
+        return player.homeBoard.contains(src.rawValue) ? Self.homeBlotPenalty : Self.blotPenalty
+    }
+
+    private func destinationBlotPenalty(for move: Move, on board: Board, player: Player) -> Int {
+        guard case .point(let dest) = move.destination else { return 0 }
+        let state = board.point(dest)
+        let landingAlone: Bool
+        if state.owner == nil {
+            landingAlone = true
+        } else if state.owner == player.opponent && state.count == 1 {
+            landingAlone = true
+        } else {
+            landingAlone = false
+        }
+        guard landingAlone else { return 0 }
+        return player.homeBoard.contains(dest.rawValue) ? Self.homeBlotPenalty : Self.blotPenalty
     }
 
     private enum ActionKind {
@@ -621,12 +756,14 @@ public struct LocalAIOpponent: Sendable {
         in state: MatchState,
         pipCounts: [Player: Int]
     ) -> Bool {
+        if difficulty == .easy { return false }
         let pointsNeeded = state.config.targetScore - state.score.score(for: offer.offeredBy)
         guard offer.proposedValue >= pointsNeeded else { return false }
 
         let opponentPips = pipCounts[opponent, default: 0]
         let offeringPlayerPips = pipCounts[offer.offeredBy, default: 0]
-        return opponentPips - offeringPlayerPips >= 50
+        let dropThreshold = difficulty == .hard ? 40 : 50
+        return opponentPips - offeringPlayerPips >= dropThreshold
     }
 
     private func projectedPipCount(_ currentPips: Int, after move: Move) -> Int {

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -131,13 +131,15 @@ public struct RootView: View {
 
     private func openMatch(_ match: ActiveMatch) {
         let rival = coordinator.rival(for: match.rivalID)
+        let aiDifficulty = AIDifficulty.fromRivalDisplayName(rival?.displayName ?? "") ?? .medium
         let viewModel = MatchViewModel(
             config: match.state.config,
             localPlayer: match.userPlayed,
             opponentName: rival?.displayName ?? "Rival",
             activeMatchID: match.id,
             initialState: match.state,
-            isOpponentAutoplayEnabled: true
+            isOpponentAutoplayEnabled: true,
+            aiDifficulty: aiDifficulty
         )
 
         viewModel.onStateChange = { [coordinator] state in

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -119,23 +119,48 @@ struct LedgerCoordinatorTests {
         #expect(records.first?.gameIndex == 0)
     }
 
-    @Test("AI rivalry starts or resumes a Local AI quick match")
+    @Test("AI rivalry starts or resumes a Medium AI quick match")
     @MainActor
     func aiRivalryStartsOrResumesQuickMatch() async throws {
         let store = InMemoryLedgerStore()
         let coordinator = LedgerCoordinator(store: store)
 
-        let firstMatch = try await coordinator.startAIRivalry()
+        let firstMatch = try await coordinator.startAIRivalry(difficulty: .medium)
         let rival = try #require(coordinator.rival(for: firstMatch.rivalID))
-        let secondMatch = try await coordinator.startAIRivalry()
+        let secondMatch = try await coordinator.startAIRivalry(difficulty: .medium)
         let rivals = try await store.loadRivals()
 
         #expect(rivals.count == 1)
-        #expect(rival.displayName == "Local AI")
+        #expect(rival.displayName == "Medium AI")
         #expect(rival.gameCenterPlayerID == nil)
         #expect(firstMatch.id == secondMatch.id)
         #expect(firstMatch.userPlayed == .white)
         #expect(firstMatch.state.config.targetScore == 1)
+    }
+
+    @Test("AI rivalry creates separate rivals per difficulty")
+    @MainActor
+    func aiRivalryCreatesSeparateRivalsPerDifficulty() async throws {
+        let store = InMemoryLedgerStore()
+        let coordinator = LedgerCoordinator(store: store)
+
+        let easyMatch = try await coordinator.startAIRivalry(difficulty: .easy)
+        let mediumMatch = try await coordinator.startAIRivalry(difficulty: .medium)
+        let hardMatch = try await coordinator.startAIRivalry(difficulty: .hard)
+
+        let easyRival = try #require(coordinator.rival(for: easyMatch.rivalID))
+        let mediumRival = try #require(coordinator.rival(for: mediumMatch.rivalID))
+        let hardRival = try #require(coordinator.rival(for: hardMatch.rivalID))
+
+        #expect(easyRival.displayName == "Easy AI")
+        #expect(mediumRival.displayName == "Medium AI")
+        #expect(hardRival.displayName == "Hard AI")
+        #expect(Set([easyRival.id, mediumRival.id, hardRival.id]).count == 3)
+
+        let resumedEasy = try await coordinator.startAIRivalry(difficulty: .easy)
+        let resumedHard = try await coordinator.startAIRivalry(difficulty: .hard)
+        #expect(resumedEasy.id == easyMatch.id)
+        #expect(resumedHard.id == hardMatch.id)
     }
 
     @Test("clearing active matches preserves rivals and completed records")

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -4,14 +4,14 @@ import Testing
 
 @Suite("Match view model")
 struct MatchViewModelTests {
-    @Test("default match is a one point Local AI quick match")
+    @Test("default match is a one point Medium AI quick match")
     @MainActor
-    func defaultMatchIsLocalAIQuickMatch() {
+    func defaultMatchIsMediumAIQuickMatch() {
         let viewModel = MatchViewModel(isOpponentAutoplayEnabled: false)
 
         #expect(viewModel.state.config.targetScore == 1)
         #expect(viewModel.localPlayer == .white)
-        #expect(viewModel.opponentName == "Local AI")
+        #expect(viewModel.opponentName == "Medium AI")
     }
 
     @Test("opening roll is applied through the engine")
@@ -410,7 +410,7 @@ struct MatchViewModelTests {
 
         #expect(passed)
         #expect(viewModel.lastError == nil)
-        #expect(viewModel.phaseTitle == "Local AI had no legal moves")
+        #expect(viewModel.phaseTitle == "Medium AI had no legal moves")
     }
 
     @Test("Local AI passes after rolling blocked bar entries")
@@ -445,7 +445,7 @@ struct MatchViewModelTests {
 
         #expect(passed)
         #expect(viewModel.lastError == nil)
-        #expect(viewModel.phaseTitle == "Local AI had no legal moves")
+        #expect(viewModel.phaseTitle == "Medium AI had no legal moves")
     }
 
     @Test("Local AI prefers the biggest pip reduction and breaks ties deterministically")
@@ -500,6 +500,65 @@ struct MatchViewModelTests {
             legalActions: legalActions,
             pipCounts: [.white: 100, .black: 150]
         ) == .dropDouble(.black))
+    }
+
+    @Test("Easy AI picks a random legal move and ignores pip bias")
+    @MainActor
+    func easyAIPicksRandomLegalMove() throws {
+        let roll = try DiceRoll(die1: 6, die2: 1)
+        let state = MatchState(
+            config: .tournament(targetScore: 1),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingMove(TurnState(player: .black, roll: roll, remainingDice: roll.playableDice))
+            )
+        )
+        let legalActions = MatchEngine.legalActions(in: state)
+        let easy = LocalAIOpponent(difficulty: .easy, randomIndex: { _ in 0 })
+
+        let action = try #require(easy.action(
+            as: .black,
+            in: state,
+            legalActions: legalActions,
+            pipCounts: [.white: 167, .black: 167]
+        ))
+
+        guard case .move(let move) = action else {
+            Issue.record("Expected easy AI to return a move action.")
+            return
+        }
+        #expect(move.player == .black)
+        #expect(legalActions.contains(.move(move)))
+    }
+
+    @Test("Hard AI prefers hitting an exposed opponent blot")
+    @MainActor
+    func hardAIHitsExposedBlot() throws {
+        var board = Board.initial()
+        try board.setPoint(PointID(rawValue: 24)!, owner: nil, count: 0)
+        try board.setPoint(PointID(rawValue: 13)!, owner: .white, count: 6)
+        try board.setPoint(PointID(rawValue: 22)!, owner: .white, count: 1)
+        let roll = try DiceRoll(die1: 5, die2: 2)
+        let state = MatchState(
+            config: .tournament(targetScore: 1),
+            game: GameState(
+                board: board,
+                phase: .awaitingMove(TurnState(player: .black, roll: roll, remainingDice: roll.playableDice))
+            )
+        )
+        let legalActions = MatchEngine.legalActions(in: state)
+        let hard = LocalAIOpponent(difficulty: .hard, randomIndex: { _ in 0 })
+
+        let move = try #require(hard.selectMove(
+            for: .black,
+            in: state,
+            legalActions: legalActions,
+            pipCounts: [.white: 167, .black: 167]
+        ))
+
+        #expect(move.source == .point(PointID(rawValue: 17)!))
+        #expect(move.destination == .point(PointID(rawValue: 22)!))
+        #expect(move.die == 5)
     }
 
     @Test("Local AI quick match can complete from automated legal play")


### PR DESCRIPTION
## Summary
- Practice vs AI now opens a Menu with Easy / Medium / Hard; each difficulty gets its own rival ledger named "Easy AI" / "Medium AI" / "Hard AI" with separate stats.
- Three distinct strategies in `LocalAIOpponent`: Easy plays a uniform-random legal move and always takes doubles; Medium keeps the existing pip-greedy behavior; Hard scores moves with hit (+50), point-making (+15/+25 inner-board), and blot-exposure (-20/-10 in home) heuristics and drops doubles at a 40-pip deficit.
- Difficulty is derived from the rival's display name in `RootView.openMatch` and threaded through `MatchViewModel` into `LocalAIOpponent`.

## Test plan
- [x] `swift test` (136 tests, including new Easy random-move and Hard hit-the-blot tests + per-difficulty coordinator test)
- [x] `xcodebuild build` and `build-for-testing` for the iOS app and test bundles
- [ ] Manual: tap Practice vs AI → confirm Menu shows Easy/Medium/Hard, picking each creates a distinct rivalry row, and resuming an existing AI rivalry reopens the correct difficulty