### PR TITLE
Randomize splash dice

### DIFF
--- a/SheshBesh/Shared/SplashView.swift
+++ b/SheshBesh/Shared/SplashView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 
 public struct SplashView: View {
     private let onFinished: () -> Void
+    private let firstDieValue: Int
+    private let secondDieValue: Int
 
     @State private var diceLanded = false
     @State private var pulse = false
@@ -9,6 +11,8 @@ public struct SplashView: View {
 
     public init(onFinished: @escaping () -> Void) {
         self.onFinished = onFinished
+        self.firstDieValue = Int.random(in: 1...6)
+        self.secondDieValue = Int.random(in: 1...6)
     }
 
     public var body: some View {
@@ -26,12 +30,12 @@ public struct SplashView: View {
 
             VStack(spacing: 36) {
                 HStack(spacing: 22) {
-                    DieView(value: 6, face: LinenBrass.cream, pip: LinenBrass.rust)
+                    DieView(value: firstDieValue, face: LinenBrass.cream, pip: LinenBrass.rust)
                         .rotationEffect(.degrees(diceLanded ? -7 : -120))
                         .offset(x: diceLanded ? 0 : -260, y: diceLanded ? 0 : -140)
                         .scaleEffect(diceLanded ? (pulse ? 1.07 : 1.0) : 0.4)
                         .opacity(diceLanded ? 1 : 0)
-                    DieView(value: 5, face: LinenBrass.rust, pip: LinenBrass.cream)
+                    DieView(value: secondDieValue, face: LinenBrass.rust, pip: LinenBrass.cream)
                         .rotationEffect(.degrees(diceLanded ? 8 : 120))
                         .offset(x: diceLanded ? 0 : 260, y: diceLanded ? 0 : -140)
                         .scaleEffect(diceLanded ? (pulse ? 1.07 : 1.0) : 0.4)

--- a/SheshBesh/Shared/SplashView.swift
+++ b/SheshBesh/Shared/SplashView.swift
@@ -2,17 +2,15 @@ import SwiftUI
 
 public struct SplashView: View {
     private let onFinished: () -> Void
-    private let firstDieValue: Int
-    private let secondDieValue: Int
 
+    @State private var firstDieValue = Int.random(in: 1...6)
+    @State private var secondDieValue = Int.random(in: 1...6)
     @State private var diceLanded = false
     @State private var pulse = false
     @State private var titleVisible = false
 
     public init(onFinished: @escaping () -> Void) {
         self.onFinished = onFinished
-        self.firstDieValue = Int.random(in: 1...6)
-        self.secondDieValue = Int.random(in: 1...6)
     }
 
     public var body: some View {


### PR DESCRIPTION
## Summary
- Randomizes the two decorative splash-screen dice once per splash view launch.
- Keeps doubles allowed and leaves all gameplay dice logic unchanged.

## Verification
- swift test
- xcodebuild -project SheshBesh.xcodeproj -scheme SheshBesh -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build