### PR TITLE
Fade splash via opacity to silence _UIReparentingView warning

### DIFF
--- a/SheshBesh/App/SheshBeshMain.swift
+++ b/SheshBesh/App/SheshBeshMain.swift
@@ -14,25 +14,32 @@ struct SheshBeshMain: App {
 }
 
 private struct RootContainer: View {
-    @State private var showSplash: Bool
+    @State private var splashOpacity: Double
+    @State private var splashRemoved: Bool
     private let root: RootView
 
     init(arguments: [String] = ProcessInfo.processInfo.arguments) {
         self.root = AppLaunchConfiguration.rootView(arguments: arguments)
         let isUITesting = arguments.contains("-uiTesting") || arguments.contains("-uiTestingRootLedger")
-        _showSplash = State(initialValue: !isUITesting)
+        _splashOpacity = State(initialValue: isUITesting ? 0 : 1)
+        _splashRemoved = State(initialValue: isUITesting)
     }
 
     var body: some View {
         ZStack {
             root
-            if showSplash {
+            if !splashRemoved {
                 SplashView(onFinished: {
                     withAnimation(.easeInOut(duration: 0.35)) {
-                        showSplash = false
+                        splashOpacity = 0
+                    }
+                    Task {
+                        try? await Task.sleep(for: .milliseconds(380))
+                        splashRemoved = true
                     }
                 })
-                .transition(.opacity)
+                .opacity(splashOpacity)
+                .allowsHitTesting(splashOpacity > 0)
             }
         }
     }

--- a/SheshBesh/App/SheshBeshMain.swift
+++ b/SheshBesh/App/SheshBeshMain.swift
@@ -14,6 +14,9 @@ struct SheshBeshMain: App {
 }
 
 private struct RootContainer: View {
+    private static let splashFadeDuration: Double = 0.35
+    private static let splashRemovalBuffer: Double = 0.05
+
     @State private var splashOpacity: Double
     @State private var splashRemoved: Bool
     private let root: RootView
@@ -30,11 +33,11 @@ private struct RootContainer: View {
             root
             if !splashRemoved {
                 SplashView(onFinished: {
-                    withAnimation(.easeInOut(duration: 0.35)) {
+                    withAnimation(.easeInOut(duration: Self.splashFadeDuration)) {
                         splashOpacity = 0
                     }
                     Task {
-                        try? await Task.sleep(for: .milliseconds(380))
+                        try? await Task.sleep(for: .seconds(Self.splashFadeDuration + Self.splashRemovalBuffer))
                         splashRemoved = true
                     }
                 })


### PR DESCRIPTION
## Summary
- `RootContainer` previously used `.transition(.opacity)` on the splash, which made SwiftUI insert a `_UIReparentingView` into `UIHostingController.view` at dismissal and emit a `com.apple.runtime-issues` fault.
- Drive the splash fade with a plain `.opacity` modifier (a stable, non-structural modifier — no reparenting helper) and only remove the view from the hierarchy after the 0.35s animation completes, so the structural removal is identity (no transition needed).
- UI-test fast-path is preserved: when launched with `-uiTesting` / `-uiTestingRootLedger`, the splash starts hidden and already-removed.

## Test plan
- [ ] Launch on a simulator from Xcode and confirm the splash fade looks identical to before.
- [ ] Confirm the purple `_UIReparentingView` runtime issue no longer fires at splash dismissal (compare against `main`).
- [ ] Run `SheshBeshUITests` to confirm the splash is still skipped under UI-test arguments.