### PR TITLE
Add local autoplay controls

### DIFF
--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/Board.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/Board.swift
@@ -105,6 +105,20 @@ public struct Board: Codable, Equatable, Hashable, Sendable {
         return true
     }
 
+    public var isNoContactRace: Bool {
+        guard whiteBar == 0, blackBar == 0 else { return false }
+
+        let whitePoints = occupiedPoints(for: .white).map(\.rawValue)
+        let blackPoints = occupiedPoints(for: .black).map(\.rawValue)
+        guard let highestWhitePoint = whitePoints.max(),
+              let lowestBlackPoint = blackPoints.min()
+        else {
+            return true
+        }
+
+        return highestWhitePoint < lowestBlackPoint
+    }
+
     public func canLand(on point: PointID, player: Player) -> Bool {
         let state = self.point(point)
         return state.owner == nil || state.owner == player || state.count == 1

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -48,6 +48,48 @@ struct BoardTests {
         #expect(board.totalCheckers(for: .white) == 15)
     }
 
+    @Test("No-contact race is true when all white checkers are below all black checkers")
+    func noContactRaceIsTrueForSeparatedCheckers() throws {
+        var board = Board.empty()
+        try board.setPoint(point(3), owner: .white, count: 5)
+        try board.setPoint(point(6), owner: .white, count: 5)
+        try board.setBorneOff(for: .white, count: 5)
+        try board.setPoint(point(19), owner: .black, count: 6)
+        try board.setPoint(point(22), owner: .black, count: 4)
+        try board.setBorneOff(for: .black, count: 5)
+
+        #expect(board.isNoContactRace)
+    }
+
+    @Test("No-contact race remains true when one side has borne off all checkers")
+    func noContactRaceAllowsBorneOffSide() throws {
+        var board = Board.empty()
+        try board.setBorneOff(for: .white, count: 15)
+        try board.setPoint(point(21), owner: .black, count: 10)
+        try board.setBorneOff(for: .black, count: 5)
+
+        #expect(board.isNoContactRace)
+    }
+
+    @Test("No-contact race is false with checkers on the bar")
+    func noContactRaceRejectsBarCheckers() throws {
+        var board = Board.empty()
+        try board.setPoint(point(4), owner: .white, count: 14)
+        try board.setBar(for: .white, count: 1)
+        try board.setPoint(point(20), owner: .black, count: 15)
+
+        #expect(!board.isNoContactRace)
+    }
+
+    @Test("No-contact race is false when checker ranges overlap")
+    func noContactRaceRejectsContactPositions() throws {
+        var board = Board.empty()
+        try board.setPoint(point(8), owner: .white, count: 15)
+        try board.setPoint(point(7), owner: .black, count: 15)
+
+        #expect(!board.isNoContactRace)
+    }
+
     @Test("Hitting from the bar preserves both players' total checker counts")
     func totalsRemainFifteenAfterBarHit() throws {
         var board = Board.empty()

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -1469,21 +1469,21 @@ private struct ActionBar: View {
                 .frame(minHeight: 48)
 
             case .awaitingRoll(let player) where player == viewModel.localPlayer:
+                resignationMenu
                 if viewModel.containsAction(.offerDouble(viewModel.localPlayer)) {
                     SecondaryActionButton(title: "Offer double") {
                         viewModel.offerDoubleIfAllowed()
                         onAction()
                     }
                 }
-                resignationMenu
-                localAutoplayButton
                 PrimaryActionButton(title: "Roll dice") {
                     viewModel.rollDiceIfAllowed()
                     onAction()
                 }
+                localAutoplayButton
 
             case .awaitingMove(let turn) where turn.player == viewModel.localPlayer:
-                localAutoplayButton
+                resignationMenu
                 if viewModel.containsAction(.passTurn(viewModel.localPlayer)) {
                     PrimaryActionButton(title: "Pass") {
                         viewModel.passIfAllowed()
@@ -1495,7 +1495,7 @@ private struct ActionBar: View {
                         .foregroundStyle(LinenBrass.cream)
                         .frame(maxWidth: .infinity, minHeight: 48)
                 }
-                resignationMenu
+                localAutoplayButton
 
             case .awaitingCubeResponse(let offer) where offer.offeredBy.opponent == viewModel.localPlayer:
                 PrimaryActionButton(title: "Take \(offer.proposedValue)") {

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -1406,7 +1406,27 @@ private struct ActionBar: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            if viewModel.isTurnDraftPending {
+            if viewModel.isRaceAutoplayActive {
+                HStack {
+                    Text(viewModel.autoplayStatusText)
+                        .font(LinenBrass.uiFont(size: 15, weight: .semibold))
+                        .foregroundStyle(LinenBrass.cream)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.76)
+                    Spacer()
+                }
+                .frame(minHeight: 48)
+
+                SecondaryActionButton(title: "Stop") {
+                    viewModel.stopRaceAutoplay()
+                    onAction()
+                }
+            } else if viewModel.canStartRaceAutoplay && !viewModel.canStartLocalAutoplay {
+                PrimaryActionButton(title: "Autoplay race") {
+                    viewModel.startRaceAutoplay()
+                    onAction()
+                }
+            } else if viewModel.isTurnDraftPending {
                 SecondaryActionButton(title: "Undo move") {
                     viewModel.undoLastMove()
                     onAction()
@@ -1456,12 +1476,14 @@ private struct ActionBar: View {
                     }
                 }
                 resignationMenu
+                localAutoplayButton
                 PrimaryActionButton(title: "Roll dice") {
                     viewModel.rollDiceIfAllowed()
                     onAction()
                 }
 
             case .awaitingMove(let turn) where turn.player == viewModel.localPlayer:
+                localAutoplayButton
                 if viewModel.containsAction(.passTurn(viewModel.localPlayer)) {
                     PrimaryActionButton(title: "Pass") {
                         viewModel.passIfAllowed()
@@ -1536,6 +1558,16 @@ private struct ActionBar: View {
             RoundedRectangle(cornerRadius: 7)
                 .stroke(LinenBrass.brass.opacity(0.32), lineWidth: 1)
         )
+    }
+
+    @ViewBuilder
+    private var localAutoplayButton: some View {
+        if viewModel.canStartLocalAutoplay {
+            SecondaryActionButton(title: "Autoplay") {
+                viewModel.startLocalAutoplay()
+                onAction()
+            }
+        }
     }
 
     @ViewBuilder

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -37,7 +37,10 @@ public final class MatchViewModel {
     private let engine: MatchEngine
     private let opponentController: LocalAIOpponent
     private let opponentDelay: @Sendable () async -> Void
+    private let raceAutoplayController: LocalAIOpponent
+    private let raceAutoplayDelay: @Sendable () async -> Void
     @ObservationIgnored private var opponentTask: Task<Void, Never>?
+    @ObservationIgnored private var raceAutoplayTask: Task<Void, Never>?
 
     public private(set) var state: MatchState
     public private(set) var checkerLayout: CheckerLayout
@@ -46,8 +49,14 @@ public final class MatchViewModel {
     public private(set) var legalMoves: [Move]
     public private(set) var pipCounts: [Player: Int]
     public private(set) var isOpponentThinking: Bool
+    public private(set) var isRaceAutoplayActive: Bool
+    public private(set) var isRaceAutoplayUserStopped: Bool
     public private(set) var turnNotice: String?
     private var turnDraftSnapshots: [(state: MatchState, layout: CheckerLayout)]
+    private var isLocalAutoplayRequested: Bool
+    private var isBatchingRaceAutoplayCallbacks: Bool
+    private var raceAutoplayNeedsStateChange: Bool
+    private var raceAutoplayNeedsCompletion: Bool
 
     public let localPlayer: Player
     public let opponentName: String
@@ -69,9 +78,13 @@ public final class MatchViewModel {
         isOpponentAutoplayEnabled: Bool = true,
         aiDifficulty: AIDifficulty = .medium,
         opponentController: LocalAIOpponent? = nil,
+        raceAutoplayController: LocalAIOpponent = LocalAIOpponent(difficulty: .medium),
         opponentDelay: @escaping @Sendable () async -> Void = {
             let nanoseconds = UInt64(Double.random(in: 0.8...1.2) * 1_000_000_000)
             try? await Task.sleep(nanoseconds: nanoseconds)
+        },
+        raceAutoplayDelay: @escaping @Sendable () async -> Void = {
+            try? await Task.sleep(nanoseconds: 180_000_000)
         }
     ) {
         let initialState = initialState ?? MatchEngine.newMatch(config: config)
@@ -86,9 +99,17 @@ public final class MatchViewModel {
         self.activeMatchID = activeMatchID
         self.opponentController = opponentController ?? LocalAIOpponent(difficulty: aiDifficulty)
         self.opponentDelay = opponentDelay
+        self.raceAutoplayController = raceAutoplayController
+        self.raceAutoplayDelay = raceAutoplayDelay
         self.isOpponentThinking = false
+        self.isRaceAutoplayActive = false
+        self.isRaceAutoplayUserStopped = false
         self.turnNotice = nil
         self.turnDraftSnapshots = []
+        self.isLocalAutoplayRequested = false
+        self.isBatchingRaceAutoplayCallbacks = false
+        self.raceAutoplayNeedsStateChange = false
+        self.raceAutoplayNeedsCompletion = false
         self.legalActions = initialLegalActions
         self.legalMoves = initialLegalActions.compactMap { action in
             if case .move(let move) = action {
@@ -100,7 +121,7 @@ public final class MatchViewModel {
         self.pipCounts = Self.computePipCounts(for: initialState.game.board)
         self.didNotifyCompletion = initialState.completion != nil
 
-        scheduleOpponentTurnIfNeeded()
+        scheduleAutomationIfNeeded()
     }
 
     public var activePlayer: Player? {
@@ -144,6 +165,7 @@ public final class MatchViewModel {
 
     public var isOpponentAutomationActive: Bool {
         guard isOpponentAutoplayEnabled else { return false }
+        guard !isRaceAutoplayActive else { return false }
         guard !isTurnDraftPending else { return false }
         return opponentController.canAct(
             as: localPlayer.opponent,
@@ -153,9 +175,22 @@ public final class MatchViewModel {
     }
 
     public var interactiveLegalMoves: [Move] {
+        guard !isRaceAutoplayActive else { return [] }
         guard !isOpponentAutomationActive else { return [] }
         guard activePlayer == localPlayer else { return [] }
         return legalMoves
+    }
+
+    public var canStartRaceAutoplay: Bool {
+        raceAutoplayTask == nil && isRaceAutoplayEligible(ignoresUserStopped: true)
+    }
+
+    public var canStartLocalAutoplay: Bool {
+        raceAutoplayTask == nil && isLocalAutoplayEligible()
+    }
+
+    public var autoplayStatusText: String {
+        isLocalAutoplayRequested ? "Autoplaying turn..." : "Autoplaying race..."
     }
 
     public var localScore: Int {
@@ -195,6 +230,10 @@ public final class MatchViewModel {
 
         if isOpponentAutomationActive {
             return isOpponentThinking ? "\(opponentName) is thinking" : "\(opponentName)'s turn"
+        }
+
+        if isRaceAutoplayActive {
+            return isLocalAutoplayRequested ? "Autoplaying turn" : "Autoplaying race"
         }
 
         if activePlayer == localPlayer, let turnNotice {
@@ -245,6 +284,7 @@ public final class MatchViewModel {
                     self.checkerLayout.apply(move)
                 } else if action == .startNextGame {
                     self.checkerLayout = CheckerLayout.reconstructed(from: nextState.game.board)
+                    self.isRaceAutoplayUserStopped = false
                 }
                 self.lastError = nil
                 self.turnDraftSnapshots.removeAll()
@@ -257,10 +297,10 @@ public final class MatchViewModel {
                 applyStateChanges()
             }
 
-            notifyStorageCallbacks(hadCompletion: hadCompletion)
+            queueOrNotifyStorageCallbacks(hadCompletion: hadCompletion)
             if schedulesOpponent {
                 turnNotice = nil
-                scheduleOpponentTurnIfNeeded()
+                scheduleAutomationIfNeeded()
             }
         } catch {
             lastError = friendlyErrorMessage(error)
@@ -307,10 +347,12 @@ public final class MatchViewModel {
         checkerLayout = CheckerLayout.reconstructed(from: nextState.game.board)
         lastError = nil
         turnDraftSnapshots.removeAll()
+        isLocalAutoplayRequested = false
+        isRaceAutoplayUserStopped = false
         didNotifyCompletion = false
         refreshDerivedState()
         onStateChange?(state)
-        scheduleOpponentTurnIfNeeded()
+        scheduleAutomationIfNeeded()
     }
 
     @discardableResult
@@ -353,8 +395,34 @@ public final class MatchViewModel {
         refreshDerivedState()
         notifyStorageCallbacks(hadCompletion: false)
         turnNotice = nil
-        scheduleOpponentTurnIfNeeded()
+        scheduleAutomationIfNeeded()
         return true
+    }
+
+    public func startRaceAutoplay() {
+        isLocalAutoplayRequested = false
+        isRaceAutoplayUserStopped = false
+        scheduleRaceAutoplayIfNeeded()
+    }
+
+    public func startLocalAutoplay() {
+        guard isLocalAutoplayEligible() else {
+            isLocalAutoplayRequested = false
+            return
+        }
+        isLocalAutoplayRequested = true
+        isRaceAutoplayUserStopped = false
+        scheduleAutoplayTaskIfNeeded()
+    }
+
+    public func stopRaceAutoplay() {
+        isRaceAutoplayUserStopped = true
+        isLocalAutoplayRequested = false
+        raceAutoplayTask?.cancel()
+        raceAutoplayTask = nil
+        isRaceAutoplayActive = false
+        flushRaceAutoplayCallbacks()
+        scheduleOpponentTurnIfNeeded()
     }
 
     public func legalDestinations(from source: MoveSource) -> [MoveDestination] {
@@ -417,7 +485,173 @@ public final class MatchViewModel {
         }
     }
 
+    private func scheduleAutomationIfNeeded() {
+        scheduleRaceAutoplayIfNeeded()
+        scheduleOpponentTurnIfNeeded()
+    }
+
+    private func scheduleRaceAutoplayIfNeeded() {
+        guard raceAutoplayTask == nil else { return }
+        guard isRaceAutoplayEligible(ignoresUserStopped: false) else { return }
+
+        isLocalAutoplayRequested = false
+        scheduleAutoplayTaskIfNeeded()
+    }
+
+    private func scheduleAutoplayTaskIfNeeded() {
+        guard raceAutoplayTask == nil else { return }
+        guard isAutoplayEligible() else { return }
+
+        isOpponentThinking = false
+        isRaceAutoplayActive = true
+        raceAutoplayTask = Task { [weak self] in
+            await self?.playRaceAutoplayUntilBlocked()
+        }
+    }
+
+    private func isAutoplayEligible() -> Bool {
+        isLocalAutoplayRequested
+            ? isLocalAutoplayEligible()
+            : isRaceAutoplayEligible(ignoresUserStopped: false)
+    }
+
+    private func isLocalAutoplayEligible() -> Bool {
+        guard state.completion == nil else { return false }
+        guard !isTurnDraftPending else { return false }
+
+        switch state.game.phase {
+        case .awaitingRoll(let player) where player == localPlayer:
+            guard !legalActions.contains(.offerDouble(localPlayer)) else { return false }
+            return legalActions.contains(.rollDice(localPlayer))
+        case .awaitingMove(let turn) where turn.player == localPlayer:
+            if legalActions.contains(where: { action in
+                if case .move(let move) = action {
+                    return move.player == localPlayer
+                }
+                return false
+            }) {
+                return true
+            }
+            return legalActions.contains(.passTurn(localPlayer))
+        default:
+            return false
+        }
+    }
+
+    private func isRaceAutoplayEligible(ignoresUserStopped: Bool) -> Bool {
+        if !ignoresUserStopped, isRaceAutoplayUserStopped {
+            return false
+        }
+        guard state.completion == nil else { return false }
+        guard state.game.board.isNoContactRace else { return false }
+        guard !isTurnDraftPending else { return false }
+
+        switch state.game.phase {
+        case .awaitingRoll(let player):
+            guard player == localPlayer || isOpponentAutoplayEnabled else { return false }
+            if player == localPlayer, legalActions.contains(.offerDouble(localPlayer)) {
+                return false
+            }
+            return legalActions.contains(.rollDice(player))
+        case .awaitingMove(let turn):
+            guard turn.player == localPlayer || isOpponentAutoplayEnabled else { return false }
+            if legalActions.contains(where: { action in
+                if case .move(let move) = action {
+                    return move.player == turn.player
+                }
+                return false
+            }) {
+                return true
+            }
+            return legalActions.contains(.passTurn(turn.player))
+        default:
+            return false
+        }
+    }
+
+    private func playRaceAutoplayUntilBlocked() async {
+        isBatchingRaceAutoplayCallbacks = true
+
+        while !Task.isCancelled {
+            guard isAutoplayEligible() else { break }
+            guard let action = autoplayAction() else { break }
+
+            await raceAutoplayDelay()
+            guard !Task.isCancelled else { break }
+            guard isAutoplayEligible() else { break }
+
+            apply(action, schedulesOpponent: false)
+            if lastError != nil { break }
+        }
+
+        isBatchingRaceAutoplayCallbacks = false
+        isRaceAutoplayActive = false
+        isLocalAutoplayRequested = false
+        raceAutoplayTask = nil
+        flushRaceAutoplayCallbacks()
+
+        if !Task.isCancelled {
+            scheduleAutomationIfNeeded()
+        }
+    }
+
+    private func autoplayAction() -> MatchAction? {
+        isLocalAutoplayRequested ? localAutoplayAction() : raceAutoplayAction()
+    }
+
+    private func localAutoplayAction() -> MatchAction? {
+        switch state.game.phase {
+        case .awaitingRoll(let player) where player == localPlayer:
+            guard !legalActions.contains(.offerDouble(localPlayer)) else { return nil }
+            return legalActions.contains(.rollDice(localPlayer)) ? .rollDice(localPlayer) : nil
+        case .awaitingMove(let turn) where turn.player == localPlayer:
+            if let move = raceAutoplayMove(for: localPlayer) {
+                return .move(move)
+            }
+            return legalActions.contains(.passTurn(localPlayer)) ? .passTurn(localPlayer) : nil
+        default:
+            return nil
+        }
+    }
+
+    private func raceAutoplayAction() -> MatchAction? {
+        switch state.game.phase {
+        case .awaitingRoll(let player):
+            guard player == localPlayer || isOpponentAutoplayEnabled else { return nil }
+            guard !(player == localPlayer && legalActions.contains(.offerDouble(localPlayer))) else {
+                return nil
+            }
+            return legalActions.contains(.rollDice(player)) ? .rollDice(player) : nil
+        case .awaitingMove(let turn):
+            guard turn.player == localPlayer || isOpponentAutoplayEnabled else { return nil }
+            if let move = raceAutoplayMove(for: turn.player) {
+                return .move(move)
+            }
+            return legalActions.contains(.passTurn(turn.player)) ? .passTurn(turn.player) : nil
+        default:
+            return nil
+        }
+    }
+
+    private func raceAutoplayMove(for player: Player) -> Move? {
+        let controller = isOpponentAutoplayEnabled ? opponentController : raceAutoplayController
+        return controller.selectMove(
+            for: player,
+            in: state,
+            legalActions: legalActions,
+            pipCounts: pipCounts
+        )
+    }
+
     private func scheduleOpponentTurnIfNeeded() {
+        guard raceAutoplayTask == nil else {
+            isOpponentThinking = false
+            return
+        }
+        guard !isRaceAutoplayEligible(ignoresUserStopped: false) else {
+            isOpponentThinking = false
+            return
+        }
         guard isOpponentAutomationActive else {
             isOpponentThinking = false
             return
@@ -432,6 +666,10 @@ public final class MatchViewModel {
 
     private func playOpponentUntilLocalTurn() async {
         while !Task.isCancelled {
+            if isRaceAutoplayEligible(ignoresUserStopped: false) {
+                scheduleRaceAutoplayIfNeeded()
+                break
+            }
             guard isOpponentAutomationActive else { break }
             isOpponentThinking = true
             await opponentDelay()
@@ -470,6 +708,32 @@ public final class MatchViewModel {
             }
         default:
             break
+        }
+    }
+
+    private func queueOrNotifyStorageCallbacks(hadCompletion: Bool) {
+        guard isBatchingRaceAutoplayCallbacks else {
+            notifyStorageCallbacks(hadCompletion: hadCompletion)
+            return
+        }
+
+        if !hadCompletion, state.completion != nil {
+            raceAutoplayNeedsCompletion = true
+        } else if state.completion == nil {
+            raceAutoplayNeedsStateChange = true
+        }
+    }
+
+    private func flushRaceAutoplayCallbacks() {
+        let shouldNotifyCompletion = raceAutoplayNeedsCompletion && state.completion != nil
+        let shouldNotifyStateChange = raceAutoplayNeedsStateChange && state.completion == nil
+        raceAutoplayNeedsCompletion = false
+        raceAutoplayNeedsStateChange = false
+
+        if shouldNotifyCompletion {
+            notifyCompletionIfNeeded()
+        } else if shouldNotifyStateChange {
+            onStateChange?(state)
         }
     }
 

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -561,6 +561,228 @@ struct MatchViewModelTests {
         #expect(move.die == 5)
     }
 
+    @Test("Race autoplay advances both players in local AI matches")
+    @MainActor
+    func raceAutoplayAdvancesBothPlayersInLocalAIMatches() async throws {
+        let initialPips = 90
+        var board = Board.empty()
+        try board.setPoint(PointID(rawValue: 6)!, owner: .white, count: 15)
+        try board.setPoint(PointID(rawValue: 19)!, owner: .black, count: 15)
+
+        let state = MatchState(
+            config: MatchConfig(targetScore: 5, usesDoublingCube: false),
+            game: GameState(board: board, phase: .awaitingRoll(.white))
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            initialState: state,
+            opponentController: LocalAIOpponent(randomIndex: { _ in 0 }),
+            opponentDelay: {},
+            raceAutoplayDelay: {}
+        )
+
+        let bothAdvanced = await waitUntil {
+            viewModel.pipCount(for: .white) < initialPips
+                && viewModel.pipCount(for: .black) < initialPips
+        }
+
+        #expect(bothAdvanced)
+        #expect(viewModel.lastError == nil)
+    }
+
+    @Test("Race autoplay in Game Center style matches only advances the local turn")
+    @MainActor
+    func raceAutoplayOnlyAdvancesLocalTurnForGameCenterStyleMatches() async throws {
+        var board = Board.empty()
+        try board.setPoint(PointID(rawValue: 6)!, owner: .white, count: 15)
+        try board.setPoint(PointID(rawValue: 19)!, owner: .black, count: 15)
+
+        let state = MatchState(
+            config: MatchConfig(targetScore: 5, usesDoublingCube: false),
+            game: GameState(board: board, phase: .awaitingRoll(.white))
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            initialState: state,
+            isOpponentAutoplayEnabled: false,
+            raceAutoplayController: LocalAIOpponent(randomIndex: { _ in 0 }),
+            raceAutoplayDelay: {}
+        )
+        var stateChangeCount = 0
+        viewModel.onStateChange = { _ in
+            stateChangeCount += 1
+        }
+
+        let handedOff = await waitUntil {
+            if case .awaitingRoll(.black) = viewModel.state.game.phase {
+                return true
+            }
+            return false
+        }
+
+        #expect(handedOff)
+        #expect(viewModel.pipCount(for: .white) < 90)
+        #expect(viewModel.pipCount(for: .black) == 90)
+        #expect(stateChangeCount == 1)
+        #expect(!viewModel.isRaceAutoplayActive)
+        #expect(viewModel.lastError == nil)
+    }
+
+    @Test("Race autoplay pauses before a local double offer")
+    @MainActor
+    func raceAutoplayPausesBeforeLocalDoubleOffer() async throws {
+        var board = Board.empty()
+        try board.setPoint(PointID(rawValue: 6)!, owner: .white, count: 15)
+        try board.setPoint(PointID(rawValue: 19)!, owner: .black, count: 15)
+
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            game: GameState(board: board, phase: .awaitingRoll(.white))
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            initialState: state,
+            isOpponentAutoplayEnabled: false,
+            raceAutoplayDelay: {}
+        )
+
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+
+        #expect(!viewModel.isRaceAutoplayActive)
+        #expect(!viewModel.canStartRaceAutoplay)
+        #expect(viewModel.containsAction(.offerDouble(.white)))
+        guard case .awaitingRoll(.white) = viewModel.state.game.phase else {
+            Issue.record("Expected autoplay to leave the local player at the roll.")
+            return
+        }
+    }
+
+    @Test("Stopping race autoplay cancels automatic restart for the current game")
+    @MainActor
+    func stoppingRaceAutoplayCancelsAutomaticRestart() async throws {
+        var board = Board.empty()
+        try board.setPoint(PointID(rawValue: 6)!, owner: .white, count: 15)
+        try board.setPoint(PointID(rawValue: 19)!, owner: .black, count: 15)
+
+        let state = MatchState(
+            config: MatchConfig(targetScore: 5, usesDoublingCube: false),
+            game: GameState(board: board, phase: .awaitingRoll(.white))
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            initialState: state
+        )
+
+        #expect(viewModel.isRaceAutoplayActive)
+        viewModel.stopRaceAutoplay()
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+
+        #expect(viewModel.isRaceAutoplayUserStopped)
+        #expect(!viewModel.isRaceAutoplayActive)
+        #expect(viewModel.canStartRaceAutoplay)
+        guard case .awaitingRoll(.white) = viewModel.state.game.phase else {
+            Issue.record("Expected stopped autoplay to leave the original turn alone.")
+            return
+        }
+    }
+
+    @Test("Race autoplay completion callback fires once")
+    @MainActor
+    func raceAutoplayCompletionCallbackFiresOnce() async throws {
+        var board = Board.empty()
+        try board.setPoint(PointID(rawValue: 1)!, owner: .white, count: 1)
+        try board.setPoint(PointID(rawValue: 24)!, owner: .black, count: 15)
+        try board.setBorneOff(for: .white, count: 14)
+
+        let roll = try DiceRoll(die1: 1, die2: 1)
+        let state = MatchState(
+            config: MatchConfig(targetScore: 1, usesDoublingCube: false),
+            game: GameState(
+                board: board,
+                phase: .awaitingMove(TurnState(player: .white, roll: roll, remainingDice: [1]))
+            )
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            initialState: state,
+            isOpponentAutoplayEnabled: false,
+            raceAutoplayDelay: {}
+        )
+        var completionCount = 0
+        viewModel.onCompletion = { _ in
+            completionCount += 1
+        }
+
+        let completed = await waitUntil {
+            viewModel.state.completion != nil
+        }
+
+        #expect(completed)
+        #expect(completionCount == 1)
+        #expect(viewModel.lastError == nil)
+    }
+
+    @Test("Local autoplay can play a turn before the race is no-contact")
+    @MainActor
+    func localAutoplayCanPlayContactTurn() async {
+        let state = MatchState(
+            config: MatchConfig(targetScore: 5, usesDoublingCube: false),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            initialState: state,
+            isOpponentAutoplayEnabled: false,
+            raceAutoplayController: LocalAIOpponent(randomIndex: { _ in 0 }),
+            raceAutoplayDelay: {}
+        )
+        var stateChangeCount = 0
+        viewModel.onStateChange = { _ in
+            stateChangeCount += 1
+        }
+
+        #expect(!viewModel.state.game.board.isNoContactRace)
+        #expect(viewModel.canStartLocalAutoplay)
+        #expect(!viewModel.canStartRaceAutoplay)
+        viewModel.startLocalAutoplay()
+
+        let handedOff = await waitUntil {
+            if case .awaitingRoll(.black) = viewModel.state.game.phase {
+                return true
+            }
+            return false
+        }
+
+        #expect(handedOff)
+        #expect(viewModel.pipCount(for: .white) < 167)
+        #expect(viewModel.pipCount(for: .black) == 167)
+        #expect(stateChangeCount == 1)
+        #expect(!viewModel.isRaceAutoplayActive)
+        #expect(viewModel.lastError == nil)
+    }
+
+    @Test("Local autoplay is unavailable before a local double offer")
+    @MainActor
+    func localAutoplayUnavailableBeforeLocalDoubleOffer() {
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            initialState: state,
+            isOpponentAutoplayEnabled: false,
+            raceAutoplayDelay: {}
+        )
+
+        #expect(viewModel.containsAction(.offerDouble(.white)))
+        #expect(!viewModel.canStartLocalAutoplay)
+    }
+
     @Test("Local AI quick match can complete from automated legal play")
     @MainActor
     func localAIQuickMatchCompletesFromLegalPlay() async {
@@ -568,13 +790,16 @@ struct MatchViewModelTests {
             engine: MatchEngine(diceRoller: CyclingDiceRoller()),
             config: .tournament(targetScore: 1),
             opponentController: LocalAIOpponent(randomIndex: { _ in 0 }),
-            opponentDelay: {}
+            opponentDelay: {},
+            raceAutoplayDelay: {}
         )
 
         var actionCount = 0
         while viewModel.state.completion == nil, actionCount < 1_000 {
             actionCount += 1
-            if viewModel.isTurnDraftPending, viewModel.canSubmitTurn {
+            if viewModel.isRaceAutoplayActive {
+                await Task.yield()
+            } else if viewModel.isTurnDraftPending, viewModel.canSubmitTurn {
                 viewModel.submitTurnIfAllowed()
             } else {
                 switch viewModel.state.game.phase {


### PR DESCRIPTION
Adds no-contact race detection and automatic race fast-forward for local AI matches. Adds a local Autoplay control that can roll and finish the local player's turn, including local-only Game Center handoff behavior. Autoplay pauses when the local player can offer a double and batches persistence callbacks while automated moves are running. Covered with board and view model tests for race detection, AI race autoplay, Game Center-style local-only autoplay, stop behavior, completion callbacks, and arbitrary local-turn autoplay. Tested with ./scripts/test.sh.