### PR TITLE
Fix yellow bleed at match end sheet's rounded corners

### DIFF
--- a/SheshBesh/Shared/MatchEndSheet.swift
+++ b/SheshBesh/Shared/MatchEndSheet.swift
@@ -68,8 +68,8 @@ public struct MatchEndSheet: View {
         .padding(.horizontal, 20)
         .padding(.bottom, 22)
         .frame(maxWidth: .infinity)
-        .background(SheetTheme.cream)
         .presentationDetents([.medium])
+        .presentationBackground(SheetTheme.cream)
     }
 
     private var rivalName: String {


### PR DESCRIPTION
## Summary
- Move the cream fill onto the sheet's presentation container via `presentationBackground` so it paints the rounded corners cleanly, instead of leaving the system default to peek through behind the inner VStack background.

## Test plan
- [ ] Finish a Practice vs AI match and confirm the match end sheet's top rounded corners show cream edge-to-edge with no darker tint bleeding through.
- [ ] Verify in dark mode that the cream still fills the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)