### PR TITLE
Prevent match scores past target

### DIFF
--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
@@ -25,14 +25,14 @@ public struct MatchEngine: Sendable {
                 actions.append(.offerDouble(player))
             }
             actions.append(.rollDice(player))
-            actions.append(contentsOf: resignationActions(for: player))
+            actions.append(contentsOf: resignationActions(for: player, in: state))
             return actions
         case .awaitingMove(let turn):
             var actions = MoveValidator.legalFirstMoves(for: turn.player, in: state.game).map(MatchAction.move)
             if actions.isEmpty {
                 actions.append(.passTurn(turn.player))
             }
-            actions.append(contentsOf: resignationActions(for: turn.player))
+            actions.append(contentsOf: resignationActions(for: turn.player, in: state))
             return actions
         case .awaitingCubeResponse(let offer):
             let responder = offer.offeredBy.opponent
@@ -203,6 +203,9 @@ public struct MatchEngine: Sendable {
         default:
             throw MatchEngineError.invalidAction("\(player.rawValue) cannot resign now.")
         }
+        guard Self.legalResignationWinKinds(for: player, in: state).contains(winKind) else {
+            throw MatchEngineError.invalidAction("\(player.rawValue) cannot offer a \(winKind.rawValue) resignation now.")
+        }
 
         var next = state
         next.game.phase = .awaitingResignationResponse(
@@ -287,7 +290,7 @@ public struct MatchEngine: Sendable {
     private static func finishGame(with result: GameResult, in state: MatchState) -> MatchState {
         var next = state
         next.game.phase = .gameOver(result)
-        next.score.add(result.points, to: result.winner)
+        next.score.add(scoredMatchPoints(for: result, in: state), to: result.winner)
 
         if next.score.score(for: result.winner) >= next.config.targetScore {
             next.completion = MatchCompletion(winner: result.winner, finalScore: next.score)
@@ -310,11 +313,28 @@ public struct MatchEngine: Sendable {
         guard !state.game.isCrawford else { return false }
         guard case .awaitingRoll(player) = state.game.phase else { return false }
         guard state.game.cube.value < state.config.maximumCubeValue else { return false }
+        guard !isCubeDead(for: player, in: state) else { return false }
         return state.game.cube.owner == nil || state.game.cube.owner == player
     }
 
-    private static func resignationActions(for player: Player) -> [MatchAction] {
-        WinKind.allCases.map { .offerResignation(player, $0) }
+    private static func resignationActions(for player: Player, in state: MatchState) -> [MatchAction] {
+        legalResignationWinKinds(for: player, in: state).map { .offerResignation(player, $0) }
+    }
+
+    private static func legalResignationWinKinds(for player: Player, in state: MatchState) -> [WinKind] {
+        let winner = player.opponent
+        let pointsNeeded = max(0, state.config.targetScore - state.score.score(for: winner))
+        let fittingKinds = WinKind.allCases.filter { state.game.cube.value * $0.multiplier <= pointsNeeded }
+        return fittingKinds.isEmpty ? [.single] : fittingKinds
+    }
+
+    private static func isCubeDead(for player: Player, in state: MatchState) -> Bool {
+        state.score.score(for: player) + state.game.cube.value >= state.config.targetScore
+    }
+
+    private static func scoredMatchPoints(for result: GameResult, in state: MatchState) -> Int {
+        let pointsNeeded = max(0, state.config.targetScore - state.score.score(for: result.winner))
+        return min(result.points, pointsNeeded)
     }
 }
 

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MatchEngine.swift
@@ -324,8 +324,19 @@ public struct MatchEngine: Sendable {
     private static func legalResignationWinKinds(for player: Player, in state: MatchState) -> [WinKind] {
         let winner = player.opponent
         let pointsNeeded = max(0, state.config.targetScore - state.score.score(for: winner))
-        let fittingKinds = WinKind.allCases.filter { state.game.cube.value * $0.multiplier <= pointsNeeded }
+        let minimumWinKind = minimumResignationWinKind(for: player, in: state.game.board)
+        let fittingKinds = WinKind.allCases.filter {
+            $0.multiplier >= minimumWinKind.multiplier && state.game.cube.value * $0.multiplier <= pointsNeeded
+        }
         return fittingKinds.isEmpty ? [.single] : fittingKinds
+    }
+
+    private static func minimumResignationWinKind(for player: Player, in board: Board) -> WinKind {
+        let winner = player.opponent
+        if board.borneOffCount(for: player) > 0 || board.borneOffCount(for: winner) == 0 {
+            return .single
+        }
+        return board.hasCheckerOnBarOrInHomeBoard(of: winner, loser: player) ? .backgammon : .gammon
     }
 
     private static func isCubeDead(for player: Player, in state: MatchState) -> Bool {

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -692,6 +692,49 @@ struct MatchEngineTests {
         #expect(actions.contains(.offerResignation(.white, .backgammon)))
     }
 
+    @Test("Resignation offers cannot understate a gammon board")
+    func resignationOffersCannotUnderstateGammonBoard() throws {
+        let engine = MatchEngine()
+        var board = Board.empty()
+        try board.setPoint(point(18), owner: .white, count: 15)
+        try board.setPoint(point(19), owner: .black, count: 14)
+        try board.setBorneOff(for: .black, count: 1)
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            game: GameState(board: board, phase: .awaitingRoll(.white))
+        )
+        let actions = MatchEngine.legalActions(in: state)
+
+        #expect(!actions.contains(.offerResignation(.white, .single)))
+        #expect(actions.contains(.offerResignation(.white, .gammon)))
+        #expect(actions.contains(.offerResignation(.white, .backgammon)))
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerResignation(.white, .single), to: state)
+        }
+    }
+
+    @Test("Resignation offers cannot understate a backgammon board")
+    func resignationOffersCannotUnderstateBackgammonBoard() throws {
+        let engine = MatchEngine()
+        var board = Board.empty()
+        try board.setBar(for: .white, count: 1)
+        try board.setPoint(point(18), owner: .white, count: 14)
+        try board.setPoint(point(19), owner: .black, count: 14)
+        try board.setBorneOff(for: .black, count: 1)
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            game: GameState(board: board, phase: .awaitingRoll(.white))
+        )
+        let actions = MatchEngine.legalActions(in: state)
+
+        #expect(!actions.contains(.offerResignation(.white, .single)))
+        #expect(!actions.contains(.offerResignation(.white, .gammon)))
+        #expect(actions.contains(.offerResignation(.white, .backgammon)))
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerResignation(.white, .gammon), to: state)
+        }
+    }
+
     @Test("A player who is one point away triggers Crawford for the next game")
     func crawfordIsQueuedAtOneAway() throws {
         let engine = MatchEngine()

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/MatchEngineTests.swift
@@ -318,11 +318,11 @@ struct MatchEngineTests {
         state = try engine.apply(action: .rollOpeningDice, to: state)
         state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
         #expect(!state.game.isCrawford)
-        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
     }
 
-    @Test("The doubling cube is available again after the Crawford game")
-    func cubeAvailableAfterCrawfordGameCompletes() throws {
+    @Test("A dead cube stays unavailable after the Crawford game")
+    func deadCubeStaysUnavailableAfterCrawfordGameCompletes() throws {
         let engine = MatchEngine(diceRoller: ScriptedDiceRoller([6, 1, 6, 1]))
         let previousResult = GameResult(winner: .black, winKind: .single, cubeValue: 1)
         var state = MatchState(
@@ -348,7 +348,37 @@ struct MatchEngineTests {
         state = try playFirstLegalMovesUntilRoll(from: state, using: engine)
 
         #expect(!state.game.isCrawford)
-        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.black)))
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerDouble(.black), to: state)
+        }
+    }
+
+    @Test("The trailer can offer the cube after the Crawford game")
+    func trailerCanOfferCubeAfterCrawfordGameCompletes() {
+        let state = MatchState(
+            config: .tournament(targetScore: 4),
+            score: MatchScore(white: 1, black: 3),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white)),
+            crawfordState: .completed
+        )
+
+        #expect(MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+    }
+
+    @Test("A player cannot double when the current cube already wins the match")
+    func deadCubePreventsMatchWinningDouble() {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            score: MatchScore(white: 6, black: 0),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        #expect(!MatchEngine.legalActions(in: state).contains(.offerDouble(.white)))
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerDouble(.white), to: state)
+        }
     }
 
     @Test("Accepted resignation scores the offered result")
@@ -532,7 +562,7 @@ struct MatchEngineTests {
     func matchCompletion() throws {
         let engine = MatchEngine()
         var state = MatchState(
-            config: .tournament(targetScore: 3),
+            config: .tournament(targetScore: 4),
             game: GameState(
                 board: .initial(),
                 phase: .awaitingRoll(.white),
@@ -547,24 +577,33 @@ struct MatchEngineTests {
         #expect(MatchEngine.legalActions(in: state).isEmpty)
     }
 
-    @Test("Match completion is recorded when points exceed targetScore")
-    func matchCompletionWhenScoreExceedsTarget() throws {
+    @Test("Match completion caps points at targetScore")
+    func matchCompletionCapsPointsAtTargetScore() throws {
         let engine = MatchEngine()
         var state = MatchState(
-            config: .tournament(targetScore: 3),
-            score: MatchScore(white: 0, black: 2),
-            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+            config: .tournament(targetScore: 7),
+            score: MatchScore(white: 0, black: 6),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingRoll(.white),
+                cube: CubeState(value: 2, owner: .black)
+            )
         )
 
-        state = try engine.apply(action: .offerResignation(.white, .gammon), to: state)
+        state = try engine.apply(action: .offerResignation(.white, .single), to: state)
         state = try engine.apply(action: .acceptResignation(.black), to: state)
 
-        #expect(state.score.score(for: .black) == 4)
+        #expect(state.score.score(for: .black) == 7)
         #expect(state.completion == MatchCompletion(winner: .black, finalScore: state.score))
+        guard case .gameOver(let result) = state.game.phase else {
+            Issue.record("Expected game over after accepted resignation")
+            return
+        }
+        #expect(result == GameResult(winner: .black, winKind: .single, cubeValue: 2))
     }
 
-    @Test("A high cube backgammon completes the match when it overshoots the target")
-    func highCubeBackgammonCanCompleteMatchBeyondTarget() throws {
+    @Test("A high cube backgammon records the raw game result but caps match score")
+    func highCubeBackgammonCapsMatchScoreAtTarget() throws {
         var board = Board.empty()
         try board.setPoint(point(1), owner: .white, count: 1)
         try board.setBorneOff(for: .white, count: 14)
@@ -581,13 +620,76 @@ struct MatchEngineTests {
         let move = Move(player: .white, source: .point(point(1)), destination: .off, die: 1)
         let next = try MatchEngine().apply(action: .move(move), to: state)
 
-        #expect(next.score.score(for: .white) == 12)
+        #expect(next.score.score(for: .white) == 5)
         #expect(next.completion == MatchCompletion(winner: .white, finalScore: next.score))
         guard case .gameOver(let result) = next.game.phase else {
             Issue.record("Expected game over after final checker bears off")
             return
         }
         #expect(result == GameResult(winner: .white, winKind: .backgammon, cubeValue: 4))
+    }
+
+    @Test("Match point resignation only allows a single")
+    func matchPointResignationOnlyAllowsSingle() {
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            score: MatchScore(white: 0, black: 6),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let actions = MatchEngine.legalActions(in: state)
+
+        #expect(actions.contains(.offerResignation(.white, .single)))
+        #expect(!actions.contains(.offerResignation(.white, .gammon)))
+        #expect(!actions.contains(.offerResignation(.white, .backgammon)))
+    }
+
+    @Test("Resignation still allows single when the cube value exceeds remaining points")
+    func resignationAllowsSingleWhenCubeExceedsRemainingPoints() {
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            score: MatchScore(white: 0, black: 6),
+            game: GameState(
+                board: .initial(),
+                phase: .awaitingRoll(.white),
+                cube: CubeState(value: 2, owner: .black)
+            )
+        )
+        let actions = MatchEngine.legalActions(in: state)
+
+        #expect(actions.contains(.offerResignation(.white, .single)))
+        #expect(!actions.contains(.offerResignation(.white, .gammon)))
+        #expect(!actions.contains(.offerResignation(.white, .backgammon)))
+    }
+
+    @Test("Direct oversized resignation offers are rejected at match point")
+    func oversizedResignationOffersAreRejectedAtMatchPoint() {
+        let engine = MatchEngine()
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            score: MatchScore(white: 0, black: 6),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerResignation(.white, .gammon), to: state)
+        }
+        expectInvalidAction {
+            _ = try engine.apply(action: .offerResignation(.white, .backgammon), to: state)
+        }
+    }
+
+    @Test("Resignation offers include larger results when they fit remaining points")
+    func largerResignationOffersRemainAvailableWhenTheyFit() {
+        let state = MatchState(
+            config: .tournament(targetScore: 7),
+            score: MatchScore(white: 0, black: 4),
+            game: GameState(board: .initial(), phase: .awaitingRoll(.white))
+        )
+        let actions = MatchEngine.legalActions(in: state)
+
+        #expect(actions.contains(.offerResignation(.white, .single)))
+        #expect(actions.contains(.offerResignation(.white, .gammon)))
+        #expect(actions.contains(.offerResignation(.white, .backgammon)))
     }
 
     @Test("A player who is one point away triggers Crawford for the next game")

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -1579,16 +1579,20 @@ private struct ActionBar: View {
                     onAction()
                 }
                 .accessibilityIdentifier("action-offer-single")
-                Button("Offer gammon") {
-                    viewModel.offerResignationIfAllowed(.gammon)
-                    onAction()
+                if viewModel.containsAction(.offerResignation(viewModel.localPlayer, .gammon)) {
+                    Button("Offer gammon") {
+                        viewModel.offerResignationIfAllowed(.gammon)
+                        onAction()
+                    }
+                    .accessibilityIdentifier("action-offer-gammon")
                 }
-                .accessibilityIdentifier("action-offer-gammon")
-                Button("Offer backgammon") {
-                    viewModel.offerResignationIfAllowed(.backgammon)
-                    onAction()
+                if viewModel.containsAction(.offerResignation(viewModel.localPlayer, .backgammon)) {
+                    Button("Offer backgammon") {
+                        viewModel.offerResignationIfAllowed(.backgammon)
+                        onAction()
+                    }
+                    .accessibilityIdentifier("action-offer-backgammon")
                 }
-                .accessibilityIdentifier("action-offer-backgammon")
             } label: {
                 Text("Resign...")
                     .font(LinenBrass.uiFont(size: 18, weight: .semibold))


### PR DESCRIPTION
Caps completed match scores at the configured target while preserving the raw game result value. Adds dead-cube protection and restricts resignation offers so match-point players cannot over-concede gammons or backgammons. Updates the resign menu to show only legal resignation outcomes. Tests cover capped scoring, dead-cube behavior, and match-point resignation rules.