### PR TITLE
Fix Practice vs AI match target

### DIFF
--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -9,7 +9,7 @@ import SheshBeshLedger
 @MainActor
 @Observable
 public final class LedgerCoordinator {
-    private static let quickAIMatchConfig = MatchConfig.tournament(targetScore: 7)
+    private static let standardAIMatchConfig = MatchConfig.tournament(targetScore: 7)
 
     @ObservationIgnored private let store: any LedgerStore
 
@@ -117,7 +117,7 @@ public final class LedgerCoordinator {
         let rival: Rival
         if let existingRival = ledgers
             .map(\.rival)
-            .first(where: { Self.isQuickAIRival($0, difficulty: difficulty) }) {
+            .first(where: { Self.isStandardAIRival($0, difficulty: difficulty) }) {
             rival = existingRival
         } else {
             rival = Rival(displayName: difficulty.rivalDisplayName)
@@ -132,7 +132,7 @@ public final class LedgerCoordinator {
         return try await startMatch(
             against: rival,
             userPlays: .white,
-            config: Self.quickAIMatchConfig
+            config: Self.standardAIMatchConfig
         )
     }
 
@@ -165,7 +165,7 @@ public final class LedgerCoordinator {
         lastErrorMessage = nil
     }
 
-    private static func isQuickAIRival(_ rival: Rival, difficulty: AIDifficulty) -> Bool {
+    private static func isStandardAIRival(_ rival: Rival, difficulty: AIDifficulty) -> Bool {
         rival.gameCenterPlayerID == nil && rival.displayName == difficulty.rivalDisplayName
     }
 

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -9,7 +9,7 @@ import SheshBeshLedger
 @MainActor
 @Observable
 public final class LedgerCoordinator {
-    private static let quickAIMatchConfig = MatchConfig.tournament(targetScore: 1)
+    private static let quickAIMatchConfig = MatchConfig.tournament(targetScore: 7)
 
     @ObservationIgnored private let store: any LedgerStore
 

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -119,9 +119,9 @@ struct LedgerCoordinatorTests {
         #expect(records.first?.gameIndex == 0)
     }
 
-    @Test("AI rivalry starts or resumes a Medium AI quick match")
+    @Test("AI rivalry starts or resumes a Medium AI match")
     @MainActor
-    func aiRivalryStartsOrResumesQuickMatch() async throws {
+    func aiRivalryStartsOrResumesMatch() async throws {
         let store = InMemoryLedgerStore()
         let coordinator = LedgerCoordinator(store: store)
 
@@ -135,7 +135,7 @@ struct LedgerCoordinatorTests {
         #expect(rival.gameCenterPlayerID == nil)
         #expect(firstMatch.id == secondMatch.id)
         #expect(firstMatch.userPlayed == .white)
-        #expect(firstMatch.state.config.targetScore == 1)
+        #expect(firstMatch.state.config.targetScore == 7)
     }
 
     @Test("AI rivalry creates separate rivals per difficulty")


### PR DESCRIPTION
## Summary
- Change Practice vs AI matches from a 1-point target to the standard 7-point target.
- Update the coordinator regression test name and expectation to match the new behavior.

## Tests
- PASS: `swift test`
- PASS: `./scripts/test.sh` before syncing with latest `origin/main`
- After merging latest `origin/main`, package build/tests passed, but the UI runner later failed bootstrapping with `signal kill before establishing connection` in the simulator.