### PR TITLE
fix: address autoplay review feedback

### DIFF
--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -124,6 +124,11 @@ public final class MatchViewModel {
         scheduleAutomationIfNeeded()
     }
 
+    deinit {
+        opponentTask?.cancel()
+        raceAutoplayTask?.cancel()
+    }
+
     public var activePlayer: Player? {
         switch state.game.phase {
         case .awaitingOpeningRoll:
@@ -524,15 +529,7 @@ public final class MatchViewModel {
             guard !legalActions.contains(.offerDouble(localPlayer)) else { return false }
             return legalActions.contains(.rollDice(localPlayer))
         case .awaitingMove(let turn) where turn.player == localPlayer:
-            if legalActions.contains(where: { action in
-                if case .move(let move) = action {
-                    return move.player == localPlayer
-                }
-                return false
-            }) {
-                return true
-            }
-            return legalActions.contains(.passTurn(localPlayer))
+            return !legalMoves.isEmpty || legalActions.contains(.passTurn(localPlayer))
         default:
             return false
         }
@@ -555,15 +552,7 @@ public final class MatchViewModel {
             return legalActions.contains(.rollDice(player))
         case .awaitingMove(let turn):
             guard turn.player == localPlayer || isOpponentAutoplayEnabled else { return false }
-            if legalActions.contains(where: { action in
-                if case .move(let move) = action {
-                    return move.player == turn.player
-                }
-                return false
-            }) {
-                return true
-            }
-            return legalActions.contains(.passTurn(turn.player))
+            return !legalMoves.isEmpty || legalActions.contains(.passTurn(turn.player))
         default:
             return false
         }
@@ -666,10 +655,6 @@ public final class MatchViewModel {
 
     private func playOpponentUntilLocalTurn() async {
         while !Task.isCancelled {
-            if isRaceAutoplayEligible(ignoresUserStopped: false) {
-                scheduleRaceAutoplayIfNeeded()
-                break
-            }
             guard isOpponentAutomationActive else { break }
             isOpponentThinking = true
             await opponentDelay()
@@ -691,6 +676,10 @@ public final class MatchViewModel {
 
         isOpponentThinking = false
         opponentTask = nil
+
+        if !Task.isCancelled {
+            scheduleAutomationIfNeeded()
+        }
     }
 
     private func refreshOpponentTurnNotice(after action: MatchAction, from previousState: MatchState) {

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -510,7 +510,17 @@ public final class MatchViewModel {
         isOpponentThinking = false
         isRaceAutoplayActive = true
         raceAutoplayTask = Task { [weak self] in
-            await self?.playRaceAutoplayUntilBlocked()
+            self?.isBatchingRaceAutoplayCallbacks = true
+
+            while !Task.isCancelled {
+                guard let step = self?.nextRaceAutoplayStep() else { break }
+
+                await step.delay()
+                guard !Task.isCancelled else { break }
+                guard self?.applyRaceAutoplayStep(step.action) == true else { break }
+            }
+
+            self?.finishRaceAutoplayTask(schedulesAutomation: !Task.isCancelled)
         }
     }
 
@@ -558,28 +568,26 @@ public final class MatchViewModel {
         }
     }
 
-    private func playRaceAutoplayUntilBlocked() async {
-        isBatchingRaceAutoplayCallbacks = true
+    private func nextRaceAutoplayStep() -> (delay: @Sendable () async -> Void, action: MatchAction)? {
+        guard isAutoplayEligible() else { return nil }
+        guard let action = autoplayAction() else { return nil }
+        return (raceAutoplayDelay, action)
+    }
 
-        while !Task.isCancelled {
-            guard isAutoplayEligible() else { break }
-            guard let action = autoplayAction() else { break }
+    private func applyRaceAutoplayStep(_ action: MatchAction) -> Bool {
+        guard isAutoplayEligible() else { return false }
+        apply(action, schedulesOpponent: false)
+        return lastError == nil
+    }
 
-            await raceAutoplayDelay()
-            guard !Task.isCancelled else { break }
-            guard isAutoplayEligible() else { break }
-
-            apply(action, schedulesOpponent: false)
-            if lastError != nil { break }
-        }
-
+    private func finishRaceAutoplayTask(schedulesAutomation: Bool) {
         isBatchingRaceAutoplayCallbacks = false
         isRaceAutoplayActive = false
         isLocalAutoplayRequested = false
         raceAutoplayTask = nil
         flushRaceAutoplayCallbacks()
 
-        if !Task.isCancelled {
+        if schedulesAutomation {
             scheduleAutomationIfNeeded()
         }
     }
@@ -649,35 +657,45 @@ public final class MatchViewModel {
 
         isOpponentThinking = true
         opponentTask = Task { [weak self] in
-            await self?.playOpponentUntilLocalTurn()
+            while !Task.isCancelled {
+                guard let delay = self?.beginOpponentAutomationStep() else { break }
+
+                await delay()
+                guard !Task.isCancelled else { break }
+                guard self?.applyOpponentAutomationStep() == true else { break }
+            }
+
+            self?.finishOpponentAutomationTask(schedulesAutomation: !Task.isCancelled)
         }
     }
 
-    private func playOpponentUntilLocalTurn() async {
-        while !Task.isCancelled {
-            guard isOpponentAutomationActive else { break }
-            isOpponentThinking = true
-            await opponentDelay()
-            guard !Task.isCancelled else { break }
+    private func beginOpponentAutomationStep() -> (@Sendable () async -> Void)? {
+        guard isOpponentAutomationActive else { return nil }
+        isOpponentThinking = true
+        return opponentDelay
+    }
 
-            guard let action = opponentController.action(
-                as: localPlayer.opponent,
-                in: state,
-                legalActions: legalActions,
-                pipCounts: pipCounts
-            ) else {
-                break
-            }
-
-            let previousState = state
-            apply(action, schedulesOpponent: false)
-            refreshOpponentTurnNotice(after: action, from: previousState)
+    private func applyOpponentAutomationStep() -> Bool {
+        guard let action = opponentController.action(
+            as: localPlayer.opponent,
+            in: state,
+            legalActions: legalActions,
+            pipCounts: pipCounts
+        ) else {
+            return false
         }
 
+        let previousState = state
+        apply(action, schedulesOpponent: false)
+        refreshOpponentTurnNotice(after: action, from: previousState)
+        return true
+    }
+
+    private func finishOpponentAutomationTask(schedulesAutomation: Bool) {
         isOpponentThinking = false
         opponentTask = nil
 
-        if !Task.isCancelled {
+        if schedulesAutomation {
             scheduleAutomationIfNeeded()
         }
     }


### PR DESCRIPTION
## Summary
Addresses PR #53 feedback by simplifying autoplay move checks to use cached `legalMoves`, explicitly canceling automation tasks on deinit, and deferring the opponent-to-race-autoplay handoff until after opponent task cleanup.

## Test plan
- `./scripts/test.sh` (Swift package build/tests and Xcode build passed; full UI phase hit a simulator signal-kill in `testPRScreenshots`)
- `xcodebuild test -project SheshBesh.xcodeproj -scheme SheshBesh -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SheshBeshUITests/SheshBeshUITests/testPRScreenshots CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project SheshBesh.xcodeproj -scheme SheshBesh -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:SheshBeshUITests CODE_SIGNING_ALLOWED=NO`