### PR TITLE
Fix AI difficulty for autoplay moves

### DIFF
--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -78,7 +78,7 @@ public final class MatchViewModel {
         isOpponentAutoplayEnabled: Bool = true,
         aiDifficulty: AIDifficulty = .medium,
         opponentController: LocalAIOpponent? = nil,
-        raceAutoplayController: LocalAIOpponent = LocalAIOpponent(difficulty: .medium),
+        raceAutoplayController: LocalAIOpponent? = nil,
         opponentDelay: @escaping @Sendable () async -> Void = {
             let nanoseconds = UInt64(Double.random(in: 0.8...1.2) * 1_000_000_000)
             try? await Task.sleep(nanoseconds: nanoseconds)
@@ -97,9 +97,11 @@ public final class MatchViewModel {
         self.opponentName = opponentName
         self.isOpponentAutoplayEnabled = isOpponentAutoplayEnabled
         self.activeMatchID = activeMatchID
-        self.opponentController = opponentController ?? LocalAIOpponent(difficulty: aiDifficulty)
+        let resolvedOpponentController = opponentController ?? LocalAIOpponent(difficulty: aiDifficulty)
+        self.opponentController = resolvedOpponentController
         self.opponentDelay = opponentDelay
         self.raceAutoplayController = raceAutoplayController
+            ?? (isOpponentAutoplayEnabled ? resolvedOpponentController : LocalAIOpponent(difficulty: .medium))
         self.raceAutoplayDelay = raceAutoplayDelay
         self.isOpponentThinking = false
         self.isRaceAutoplayActive = false
@@ -634,8 +636,7 @@ public final class MatchViewModel {
     }
 
     private func raceAutoplayMove(for player: Player) -> Move? {
-        let controller = isOpponentAutoplayEnabled ? opponentController : raceAutoplayController
-        return controller.selectMove(
+        raceAutoplayController.selectMove(
             for: player,
             in: state,
             legalActions: legalActions,

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -101,7 +101,7 @@ public final class MatchViewModel {
         self.opponentController = resolvedOpponentController
         self.opponentDelay = opponentDelay
         self.raceAutoplayController = raceAutoplayController
-            ?? (isOpponentAutoplayEnabled ? resolvedOpponentController : LocalAIOpponent(difficulty: .medium))
+            ?? (isOpponentAutoplayEnabled ? resolvedOpponentController : LocalAIOpponent(difficulty: aiDifficulty))
         self.raceAutoplayDelay = raceAutoplayDelay
         self.isOpponentThinking = false
         self.isRaceAutoplayActive = false

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -587,6 +587,30 @@ struct MatchViewModelTests {
         #expect(viewModel.lastError == nil)
     }
 
+    @Test("Local autoplay respects AI difficulty without opponent automation")
+    @MainActor
+    func localAutoplayRespectsAIDifficultyWithoutOpponentAutomation() async throws {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            localPlayer: .black,
+            initialState: try autoplayDifficultyProbeState(),
+            isOpponentAutoplayEnabled: false,
+            aiDifficulty: .hard,
+            raceAutoplayDelay: {}
+        )
+
+        #expect(viewModel.canStartLocalAutoplay)
+        viewModel.startLocalAutoplay()
+
+        let hitBlot = await waitUntil {
+            viewModel.state.game.board.barCount(for: .white) == 1
+        }
+
+        #expect(hitBlot)
+        #expect(viewModel.state.game.board.point(PointID(rawValue: 22)!).owner == .black)
+        #expect(viewModel.lastError == nil)
+    }
+
     @Test("Easy AI local autoplay keeps deterministic random selection")
     @MainActor
     func easyAILocalAutoplayKeepsDeterministicRandomSelection() async throws {

--- a/SheshBeshTests/MatchViewModelTests.swift
+++ b/SheshBeshTests/MatchViewModelTests.swift
@@ -561,6 +561,60 @@ struct MatchViewModelTests {
         #expect(move.die == 5)
     }
 
+    @Test("Hard AI difficulty drives local autoplay move selection")
+    @MainActor
+    func hardAIDifficultyDrivesLocalAutoplayMoveSelection() async throws {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            localPlayer: .black,
+            initialState: try autoplayDifficultyProbeState(),
+            aiDifficulty: .hard,
+            opponentDelay: {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+            },
+            raceAutoplayDelay: {}
+        )
+
+        #expect(viewModel.canStartLocalAutoplay)
+        viewModel.startLocalAutoplay()
+
+        let hitBlot = await waitUntil {
+            viewModel.state.game.board.barCount(for: .white) == 1
+        }
+
+        #expect(hitBlot)
+        #expect(viewModel.state.game.board.point(PointID(rawValue: 22)!).owner == .black)
+        #expect(viewModel.lastError == nil)
+    }
+
+    @Test("Easy AI local autoplay keeps deterministic random selection")
+    @MainActor
+    func easyAILocalAutoplayKeepsDeterministicRandomSelection() async throws {
+        let viewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([1, 1])),
+            localPlayer: .black,
+            initialState: try autoplayDifficultyProbeState(),
+            aiDifficulty: .easy,
+            opponentController: LocalAIOpponent(difficulty: .easy, randomIndex: { _ in 0 }),
+            opponentDelay: {
+                try? await Task.sleep(nanoseconds: 10_000_000_000)
+            },
+            raceAutoplayDelay: {}
+        )
+
+        #expect(viewModel.canStartLocalAutoplay)
+        viewModel.startLocalAutoplay()
+
+        let movedQuietly = await waitUntil {
+            viewModel.state.game.board.point(PointID(rawValue: 6)!).owner == .black
+        }
+
+        #expect(movedQuietly)
+        #expect(viewModel.state.game.board.barCount(for: .white) == 0)
+        #expect(viewModel.state.game.board.point(PointID(rawValue: 22)!).owner == .white)
+        #expect(viewModel.lastError == nil)
+    }
+
     @Test("Race autoplay advances both players in local AI matches")
     @MainActor
     func raceAutoplayAdvancesBothPlayersInLocalAIMatches() async throws {
@@ -863,6 +917,22 @@ private func advanceToOpponentRoll(_ viewModel: MatchViewModel) {
         to: .point(PointID(rawValue: 23)!)
     )
     _ = viewModel.submitTurnIfAllowed()
+}
+
+private func autoplayDifficultyProbeState() throws -> MatchState {
+    var board = Board.empty()
+    try board.setPoint(PointID(rawValue: 1)!, owner: .black, count: 1)
+    try board.setPoint(PointID(rawValue: 17)!, owner: .black, count: 1)
+    try board.setPoint(PointID(rawValue: 22)!, owner: .white, count: 1)
+
+    let roll = try DiceRoll(die1: 5, die2: 2)
+    return MatchState(
+        config: MatchConfig(targetScore: 1, usesDoublingCube: false),
+        game: GameState(
+            board: board,
+            phase: .awaitingMove(TurnState(player: .black, roll: roll, remainingDice: [5]))
+        )
+    )
 }
 
 private final class ScriptedDiceRoller: DiceRolling, @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Resolve the autoplay controller from the selected AI difficulty in AI matches.
- Keep explicit autoplay controller injection authoritative, and honor explicit aiDifficulty for local autoplay fallback while preserving Medium as the default.
- Add regression tests for Hard, Easy, and non-opponent local autoplay move selection.

## Verification
- swift test --filter MatchViewModelTests
- swift test
- xcodebuild -project SheshBesh.xcodeproj -scheme SheshBesh -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build

Note: ./scripts/test.sh and ./scripts/test-ui.sh previously hit a simulator runner kill in testPRScreenshots() after the first two UI tests passed.