### PR TITLE
Make incoming Game Center invitations acceptable from rivalries UI

### DIFF
--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -227,6 +227,7 @@ public struct GameCenterLoadedMatch {
     public var activeMatch: ActiveMatch
     public var rival: Rival
     public var localPlayerID: String
+    public var localParticipantStatus: GKTurnBasedParticipant.Status
 
     public var localPlayer: Player {
         envelope.playerMapping.player(forGameCenterID: localPlayerID) ?? .white
@@ -255,6 +256,9 @@ public final class GameCenterMatchCoordinator {
 
     public func load(match: GKTurnBasedMatch, targetScore: Int = 7) async throws -> GameCenterLoadedMatch {
         let localPlayerID = GKLocalPlayer.local.gamePlayerID
+        let localParticipant = match.participants.first {
+            $0.player?.gamePlayerID == localPlayerID
+        }
         let data = try await match.loadMatchData()
         let envelope: GameCenterMatchEnvelope
 
@@ -275,12 +279,18 @@ public final class GameCenterMatchCoordinator {
                 localPlayerID: localPlayerID,
                 targetScore: targetScore
             )
-            if match.currentParticipant?.player?.gamePlayerID == localPlayerID {
+            if match.currentParticipant?.player?.gamePlayerID == localPlayerID,
+               localParticipant?.status == .active {
                 try await save(envelope: envelope, to: match)
             }
         }
 
-        return try await reconcileLedger(for: match, envelope: envelope, localPlayerID: localPlayerID)
+        return try await reconcileLedger(
+            for: match,
+            envelope: envelope,
+            localPlayerID: localPlayerID,
+            localParticipantStatus: localParticipant?.status ?? .unknown
+        )
     }
 
     public func commit(state: MatchState, for loaded: GameCenterLoadedMatch) async throws -> GameCenterLoadedMatch {
@@ -318,10 +328,14 @@ public final class GameCenterMatchCoordinator {
             try await match.saveCurrentTurn(withMatch: data)
         }
 
+        let localParticipant = match.participants.first {
+            $0.player?.gamePlayerID == loaded.localPlayerID
+        }
         let updated = try await reconcileLedger(
             for: match,
             envelope: envelope,
-            localPlayerID: loaded.localPlayerID
+            localPlayerID: loaded.localPlayerID,
+            localParticipantStatus: localParticipant?.status ?? .unknown
         )
 
         if state.completion != nil {
@@ -365,7 +379,8 @@ public final class GameCenterMatchCoordinator {
     private func reconcileLedger(
         for match: GKTurnBasedMatch,
         envelope: GameCenterMatchEnvelope,
-        localPlayerID: String
+        localPlayerID: String,
+        localParticipantStatus: GKTurnBasedParticipant.Status
     ) async throws -> GameCenterLoadedMatch {
         await ledgerCoordinator.refresh()
 
@@ -399,7 +414,8 @@ public final class GameCenterMatchCoordinator {
             envelope: envelope,
             activeMatch: activeMatch,
             rival: rival,
-            localPlayerID: localPlayerID
+            localPlayerID: localPlayerID,
+            localParticipantStatus: localParticipantStatus
         )
     }
 
@@ -664,7 +680,8 @@ public struct GameCenterHomeView: View {
                         ledgers: ledgerCoordinator.ledgers,
                         onStart: startMatch,
                         onResume: resumeMatch,
-                        onDelete: requestDelete
+                        onDelete: requestDelete,
+                        inertStatus: inertStatusFor
                     )
                 }
             }
@@ -749,6 +766,30 @@ public struct GameCenterHomeView: View {
 
     private var loadedMatchesByID: [String: GameCenterLoadedMatch] {
         Dictionary(matches.map { ($0.match.matchID, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    private var inertStatusByMatchID: [String: String] {
+        var result: [String: String] = [:]
+        for loaded in matches {
+            switch loaded.localParticipantStatus {
+            case .declined:
+                result[loaded.match.matchID] = "Invitation declined"
+            case .done:
+                if loaded.envelope.state.completion == nil {
+                    result[loaded.match.matchID] = "Match ended"
+                }
+            default:
+                continue
+            }
+        }
+        return result
+    }
+
+    private func inertStatusFor(_ ledger: RivalLedger) -> String? {
+        guard let gameCenterMatchID = ledger.activeMatch?.gameCenterMatchID else {
+            return nil
+        }
+        return inertStatusByMatchID[gameCenterMatchID]
     }
 
     private var removeAllConfirmationMessage: String {
@@ -877,20 +918,37 @@ public struct GameCenterHomeView: View {
         isLoadingMatches = true
         defer { isLoadingMatches = false }
 
+        let gameCenterMatches: [GKTurnBasedMatch]
         do {
-            let gameCenterMatches = try await session.loadMatches()
-            var loaded: [GameCenterLoadedMatch] = []
-            for match in gameCenterMatches {
-                loaded.append(try await matchCoordinator.load(match: match, targetScore: selectedTargetScore))
-            }
-            matches = loaded.sorted { lhs, rhs in
-                if lhs.isLocalTurn != rhs.isLocalTurn {
-                    return lhs.isLocalTurn
-                }
-                return lhs.match.creationDate > rhs.match.creationDate
-            }
+            gameCenterMatches = try await session.loadMatches()
         } catch {
             localError = error.localizedDescription
+            return
+        }
+
+        var loaded: [GameCenterLoadedMatch] = []
+        var failures: [String] = []
+        for match in gameCenterMatches {
+            do {
+                loaded.append(try await matchCoordinator.load(match: match, targetScore: selectedTargetScore))
+            } catch {
+                failures.append("\(match.matchID): \(error.localizedDescription)")
+            }
+        }
+
+        if !failures.isEmpty {
+            gcLog.error("refresh() skipped \(failures.count, privacy: .public) match(es): \(failures.joined(separator: " | "), privacy: .private)")
+        }
+
+        matches = loaded.sorted { lhs, rhs in
+            if lhs.isLocalTurn != rhs.isLocalTurn {
+                return lhs.isLocalTurn
+            }
+            return lhs.match.creationDate > rhs.match.creationDate
+        }
+
+        if loaded.isEmpty, let firstFailure = failures.first {
+            localError = firstFailure
         }
     }
 

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -641,7 +641,8 @@ public struct GameCenterHomeView: View {
     }
 
     public var body: some View {
-        ZStack {
+        let inertStatusMap = inertStatusByMatchID
+        return ZStack {
             LedgerBackground()
                 .ignoresSafeArea()
 
@@ -681,7 +682,10 @@ public struct GameCenterHomeView: View {
                         onStart: startMatch,
                         onResume: resumeMatch,
                         onDelete: requestDelete,
-                        inertStatus: inertStatusFor
+                        inertStatus: { ledger in
+                            guard let id = ledger.activeMatch?.gameCenterMatchID else { return nil }
+                            return inertStatusMap[id]
+                        }
                     )
                 }
             }
@@ -783,13 +787,6 @@ public struct GameCenterHomeView: View {
             }
         }
         return result
-    }
-
-    private func inertStatusFor(_ ledger: RivalLedger) -> String? {
-        guard let gameCenterMatchID = ledger.activeMatch?.gameCenterMatchID else {
-            return nil
-        }
-        return inertStatusByMatchID[gameCenterMatchID]
     }
 
     private var removeAllConfirmationMessage: String {

--- a/SheshBesh/Shared/HomeView.swift
+++ b/SheshBesh/Shared/HomeView.swift
@@ -330,12 +330,14 @@ struct RivalryStack: View {
     let onStart: (RivalLedger) -> Void
     let onResume: (ActiveMatch) -> Void
     var onDelete: (RivalLedger) -> Void = { _ in }
+    var inertStatus: (RivalLedger) -> String? = { _ in nil }
 
     var body: some View {
         ForEach(Array(ledgers.enumerated()), id: \.element.rival.id) { index, ledger in
             RivalryCard(
                 ledger: ledger,
                 isHero: index == 0,
+                inertStatus: inertStatus(ledger),
                 onStart: { onStart(ledger) },
                 onResume: {
                     if let match = ledger.activeMatch {
@@ -358,6 +360,7 @@ struct RivalryStack: View {
 private struct RivalryCard: View {
     let ledger: RivalLedger
     let isHero: Bool
+    var inertStatus: String? = nil
     let onStart: () -> Void
     let onResume: () -> Void
 
@@ -394,10 +397,12 @@ private struct RivalryCard: View {
                         .monospacedDigit()
                         .accessibilityIdentifier("ledger-score-\(ledger.rival.id.uuidString)")
 
-                    Image(systemName: "chevron.right")
-                        .font(LedgerTheme.uiFont(size: isHero ? 16 : 14, weight: .semibold))
-                        .foregroundStyle(LedgerTheme.mutedInk)
-                        .accessibilityHidden(true)
+                    if inertStatus == nil {
+                        Image(systemName: "chevron.right")
+                            .font(LedgerTheme.uiFont(size: isHero ? 16 : 14, weight: .semibold))
+                            .foregroundStyle(LedgerTheme.mutedInk)
+                            .accessibilityHidden(true)
+                    }
                 }
 
                 HStack(spacing: 10) {
@@ -408,11 +413,25 @@ private struct RivalryCard: View {
             }
         }
         .buttonStyle(RivalryRowButtonStyle(isHero: isHero))
-        .accessibilityIdentifier("\(ledger.activeMatch == nil ? "start" : "resume")-match-\(ledger.rival.id.uuidString)")
-        .accessibilityLabel("\(ledger.activeMatch == nil ? "Start" : "Resume") match against \(ledger.rival.displayName). Score: \(ledger.userWins) to \(ledger.rivalWins). \(statusLine)")
+        .disabled(inertStatus != nil)
+        .accessibilityIdentifier(accessibilityIdentifier)
+        .accessibilityLabel("\(accessibilityVerb) match against \(ledger.rival.displayName). Score: \(ledger.userWins) to \(ledger.rivalWins). \(statusLine)")
+    }
+
+    private var accessibilityIdentifier: String {
+        if inertStatus != nil {
+            return "inert-match-\(ledger.rival.id.uuidString)"
+        }
+        return "\(ledger.activeMatch == nil ? "start" : "resume")-match-\(ledger.rival.id.uuidString)"
+    }
+
+    private var accessibilityVerb: String {
+        if inertStatus != nil { return "Closed" }
+        return ledger.activeMatch == nil ? "Start" : "Resume"
     }
 
     private func primaryAction() {
+        if inertStatus != nil { return }
         if ledger.activeMatch == nil {
             onStart()
         } else {
@@ -421,6 +440,8 @@ private struct RivalryCard: View {
     }
 
     private var statusLine: String {
+        if let inertStatus { return inertStatus }
+
         if let activeMatch = ledger.activeMatch {
             return activeStatus(for: activeMatch)
         }


### PR DESCRIPTION
## Summary

- `GameCenterMatchCoordinator.load(match:)` no longer calls `saveCurrentTurn` while the local participant is `.invited` (invalid per GameKit) — the first persistence happens later when `commit()`'s `endTurn` implicitly accepts.
- `GameCenterHomeView.refresh()` runs each match through its own `do/catch` so one corrupt or unsavable match no longer wipes the rivalries list; failures are logged via `gcLog` and only surfaced as an alert when zero matches loaded.
- `.declined` / `.done` participant matches that GameKit keeps surfacing now render as inert "Invitation declined" / "Match ended" cards, via a new optional `inertStatus` seam threaded through `RivalryStack` / `RivalryCard` (chevron hidden, button disabled, swipe-to-delete still works).
- Result: tapping "Invite Friend" opens Apple's matchmaker (already configured with `showExistingMatches = true`), and accepting an incoming invite there now reliably loads and opens the match.

## Test plan
- [x] `swift test` — 158/158 pass
- [x] `scripts/test.sh` (CI mode) — Swift build, Swift tests, Xcode app build, UI test build all succeed
- [ ] Two-account device sandbox: A invites B → B accepts via matchmaker → BoardView opens → first move ends turn back to A
- [ ] Two-account device sandbox: B declines via matchmaker → row shows "Invitation declined", non-tappable, swipe-removable

🤖 Generated with [Claude Code](https://claude.com/claude-code)