### PR TITLE
Scene-based PR screenshot pipeline

### DIFF
--- a/.claude/skills/pr-screenshots/SKILL.md
+++ b/.claude/skills/pr-screenshots/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: pr-screenshots
+description: Capture relevant iOS simulator screenshots for a shesh-besh PR before opening it. Inspects the staged/unstaged diff (and the diff vs main if on a branch), figures out which named scenes are actually affected, runs only those scenes from the deterministic XCUITest screenshot pipeline, and surfaces the resulting image paths so they can be referenced in the PR body. Use this whenever you are about to create or update a PR in this repo, whenever the user says "ship", "open a PR", "create a PR", or asks for screenshots, before-and-afters, or visual evidence of a change. Also use proactively when the user has finished work on the iOS app (anything under SheshBesh/) and is moving toward landing it. Skip when the diff is purely engine/ledger/tests/docs with no UI surface touched.
+---
+
+# pr-screenshots
+
+A skill for the shesh-besh iOS app. The repo ships a scene-based screenshot pipeline:
+
+- `SheshBeshUITests/PRScreenshotsTests.swift` — one `testCapture_<SceneName>` method per named scene. Each launches the app with `-uiTestScene <name>` and attaches one or more screenshots.
+- `SheshBesh/Shared/AppLaunchConfiguration.swift` — defines the `UITestScene` enum and seeds the right state for each scene (deterministic dice for the board, in-memory ledger for the rivalries home, pre-completed records for match-end sheets, and so on).
+- `scripts/capture-pr-screenshots.sh` — boots a simulator, runs the requested scenes, and exports PNGs into `.context/pr-screenshots/`. Honors `PR_SCREENSHOT_SCENES`, `IOS_TEST_DESTINATION`, `SCREENSHOT_DIR`, `RESULT_BUNDLE_PATH`.
+
+Your job is to use that pipeline intelligently — pick the right scenes for the diff, run them, and report the paths.
+
+## Mental model
+
+A bad outcome is taking screenshots that don't show the change. They look like evidence but aren't, and they erode reviewer trust in future PR screenshots. So the question this skill answers is **"which scenes does this diff actually affect?"** Then it runs only those scenes — not all of them, and not none of them.
+
+## Scenes currently available
+
+Keep this list up to date with `AppLaunchConfiguration.UITestScene` and `PRScreenshotsTests`. If the diff hits an area that no scene covers, treat that as a coverage gap (see "Extending coverage" below).
+
+| Scene | What it captures | Files where a change typically means run this scene |
+|---|---|---|
+| `board-opening` | The in-game board: opening-roll state, dice rolled (6-1), and post-first-turn. Three frames. | `SheshBesh/Shared/BoardView.swift`, `CheckerLayout.swift`, `MatchViewModel.swift`, dice/turn UI, `Assets.xcassets/` board/checker/dice/frame textures, `Info.plist` if it changes how the board renders |
+| `rivalries-home` | The rivalries home screen with one seeded AI rival and one resumable match. | `SheshBesh/Shared/HomeView.swift`, `RootView.swift` (when changing the home branch), `LedgerCoordinator.swift`, `GameCenterEnvelope.swift`/`GameCenterSupport.swift` if they affect the home UI |
+| `match-end-you-won` | The post-game sheet over the board, "You won" variant. | `SheshBesh/Shared/MatchEndSheet.swift`, sheet theme/typography helpers, anything that materially changes the "you won" header, ledger numbers, or streak rendering |
+| `match-end-rival-won` | Same sheet, "Rival won" variant. Capture this when a change affects the headline string, the rival name styling, or anything where the "rival" branch differs from the "you" branch. | Same as above; usually run alongside `match-end-you-won` rather than instead of it |
+
+## Workflow
+
+### 1. Read the diff
+
+Determine the scope of changes. Prefer the branch-vs-main diff when on a feature branch:
+
+```bash
+# If on a feature branch:
+git diff --name-only main...HEAD
+
+# Otherwise (working on main, or no branch yet), include working tree:
+git diff --name-only HEAD
+git status --porcelain
+```
+
+If both yield nothing, there's nothing to screenshot — say so and stop.
+
+### 2. Pick scenes
+
+Walk the file list and accumulate a set of scene names per the table above. A few patterns worth knowing:
+
+- A change to `MatchEndSheet.swift` almost always means **both** match-end scenes (`match-end-you-won` AND `match-end-rival-won`) — the sheet branches on `record.winner`, so the two variants exercise different code paths.
+- A change in `Assets.xcassets/` only matters if the asset is actually rendered by a scene. Assets used only by `SplashView`, GameCenter, or other uncovered surfaces don't trigger any scene.
+- Pure logic / engine / ledger changes (`Packages/SheshBeshGame/`, `Packages/SheshBeshLedger/`, `SheshBeshTests/`) trigger no scenes — skip screenshots entirely.
+- `SheshBeshUITests/`, `scripts/`, `*.md`, `.github/workflows/*.yml` — no scenes.
+- Ambiguous app-level files (`SheshBeshMain.swift`, `Info.plist`, `AppLaunchConfiguration.swift`, entitlements) — read the actual diff. If the change steers toward a specific surface, pick that surface's scene; if it's pure plumbing, no scenes.
+
+When in doubt, read the diff for that file (not just the path). A one-line tweak that only renames a private helper changes nothing on screen; running scenes for it is wasted time.
+
+### 3. Decide and announce
+
+Choose one of three outcomes and tell the user **before** doing it (each scene takes ~10–25s of simulator time — don't surprise people):
+
+- **Run a specific subset of scenes.** State which scenes and which files drove the choice. Example: "BoardView.swift and MatchEndSheet.swift changed; running `board-opening`, `match-end-you-won`, `match-end-rival-won`."
+- **Skip with reason.** State why. Example: "Diff is `Packages/SheshBeshGame/Sources/...` only; no UI affected — skipping screenshots."
+- **Run a subset and flag a gap.** Some files are covered by scenes, others touch a surface no scene currently captures (e.g. `SplashView.swift`). Run the covered scenes and explicitly say which surfaces won't be in the output. Don't silently produce a partial set.
+
+### 4. Run the script
+
+Pass the chosen scenes via `PR_SCREENSHOT_SCENES`. Unset it only if you want all scenes (which is rarely the right choice — this PR almost certainly didn't change every surface):
+
+```bash
+PR_SCREENSHOT_SCENES=board-opening,match-end-you-won ./scripts/capture-pr-screenshots.sh
+```
+
+Capture stdout — the script prints the resulting PNG paths.
+
+If the script fails:
+- **xcodebuild can't find a simulator** — check `xcrun simctl list devices available | grep iPhone`. The default destination is `platform=iOS Simulator,name=iPhone 17,OS=latest`. Override via `IOS_TEST_DESTINATION` if needed. Don't silently fall back; tell the user.
+- **A UI test fails** — that's a real bug surfaced by the screenshot pipeline. Read the failure, share it, let the user decide whether the PR is even ready.
+- **Unknown scene name** — the script will exit with a list of known scenes. Either pick a known one or extend coverage (below).
+- **No attachments exported** — usually means the test ran but `attachScreenshot(named:)` calls didn't fire. Check the test method.
+
+### 5. Report
+
+Emit a short summary the PR-creation step can use directly:
+
+- The list of PNG paths.
+- Optionally, one short line per screenshot describing the moment captured (the file names already encode this — `match-end-you-won.png` is self-explanatory).
+- Any coverage gaps you flagged in step 3.
+
+This skill produces the screenshots and surfaces the paths — it does not push to git, edit the PR body, or upload anywhere. The /ship flow or the user owns that step.
+
+## Extending coverage
+
+If the diff hits a real UI surface that no scene currently covers (e.g. `SplashView.swift`, `DoubleOfferSheet`, GameCenter pickers), the path forward is:
+
+1. Add a case to `AppLaunchConfiguration.UITestScene` in `SheshBesh/Shared/AppLaunchConfiguration.swift`. Implement its `rootView(arguments:)` so the app launches directly into that surface — typically by seeding state and using the existing `RootView` debug initializers, or by adding a new debug initializer if the surface needs one.
+2. Add a `testCapture_<SceneName>` method to `SheshBeshUITests/PRScreenshotsTests.swift` that launches with `-uiTestScene <new-scene>` and attaches a screenshot.
+3. Add the scene to the `SCENE_NAMES`/`test_name_for_scene` mapping in `scripts/capture-pr-screenshots.sh`.
+4. Update the table in this SKILL.md.
+
+This is real work — confirm scope with the user before doing it. Don't add scenes speculatively.
+
+## What this skill is NOT
+
+- It is not a general "test the iOS app" runner — for that, use `scripts/test.sh` or `xcodebuild test`.
+- It does not push to git, create PRs, or comment on GitHub. It produces screenshots and a path list. The /ship flow or the user owns the PR.
+- It is not a replacement for design review. Screenshots show *what changed*, not *whether the change is good*.
+
+## Why this matters
+
+Screenshots that genuinely show the change save reviewers minutes of pulling the branch and running the simulator themselves. Screenshots that don't show the change waste reviewer attention and erode trust in future screenshots. Picking the right subset of scenes — instead of always running everything or always skipping — is the whole point of this skill.

--- a/.claude/skills/pr-screenshots/evals/evals.json
+++ b/.claude/skills/pr-screenshots/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "pr-screenshots",
+  "evals": [
+    {
+      "id": 1,
+      "name": "board-tweak",
+      "prompt": "I just finished tightening up the spacing at the top of the in-game board view (BoardView.swift, the VStack right under the linen background). I'm about to open a PR for this on shesh-besh — handle screenshots first please.",
+      "expected_output": "Skill identifies BoardView.swift as a covered surface, runs scripts/capture-pr-screenshots.sh, and reports the captured PNG paths. Should NOT skip and should NOT flag a coverage gap.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "engine-only",
+      "prompt": "Just landed a small helper on Player in the SheshBeshGame package (isOpponentHomePoint). Ready to push a PR — sort out screenshots before I do.",
+      "expected_output": "Skill recognizes the change is purely engine logic under Packages/SheshBeshGame/, skips the screenshot script, and explicitly says no UI was affected. Should NOT boot a simulator or run the script.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "match-end-sheet",
+      "prompt": "I tweaked the handle on the match-end sheet — different spacing and a slightly bolder brass tint on the capsule. Going to open a PR now, but get screenshots together first.",
+      "expected_output": "Skill identifies MatchEndSheet.swift as a visual change but NOT covered by the existing testPRScreenshots flow. Should NOT just blindly run the script (those screenshots wouldn't show the change). Should explicitly call out the gap and either offer to extend the UI test or recommend skipping with a note in the PR.",
+      "files": []
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ playground.xcworkspace
 .env.*
 !.env.example
 .gstack/
+
+# Local screenshot output and skill workspaces (not shipped)
+.context/
+.claude/skills/*/workspace/
+.claude/skills/*-workspace/

--- a/SheshBesh.xcodeproj/project.pbxproj
+++ b/SheshBesh.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		AF1000000000000000000036 /* AppLaunchConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF1000000000000000000037 /* AppLaunchConfiguration.swift */; };
 		AF1000000000000000000038 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AF1000000000000000000039 /* Assets.xcassets */; };
 		AF2000000000000000000001 /* SheshBeshUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2000000000000000000002 /* SheshBeshUITests.swift */; };
+		AF2000000000000000000010 /* PRScreenshotsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2000000000000000000011 /* PRScreenshotsTests.swift */; };
 		AF3000000000000000000001 /* LedgerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3000000000000000000002 /* LedgerCoordinator.swift */; };
 		AF3000000000000000000003 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3000000000000000000004 /* HomeView.swift */; };
 		AF3000000000000000000005 /* MatchEndSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3000000000000000000006 /* MatchEndSheet.swift */; };
@@ -75,6 +76,7 @@
 		AF1000000000000000000037 /* AppLaunchConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchConfiguration.swift; sourceTree = "<group>"; };
 		AF1000000000000000000039 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AF2000000000000000000002 /* SheshBeshUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheshBeshUITests.swift; sourceTree = "<group>"; };
+		AF2000000000000000000011 /* PRScreenshotsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRScreenshotsTests.swift; sourceTree = "<group>"; };
 		AF2000000000000000000003 /* SheshBeshUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SheshBeshUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF3000000000000000000002 /* LedgerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LedgerCoordinator.swift; sourceTree = "<group>"; };
 		AF3000000000000000000004 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -220,6 +222,7 @@
 			isa = PBXGroup;
 			children = (
 				AF2000000000000000000002 /* SheshBeshUITests.swift */,
+				AF2000000000000000000011 /* PRScreenshotsTests.swift */,
 			);
 			path = SheshBeshUITests;
 			sourceTree = "<group>";
@@ -419,6 +422,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AF2000000000000000000001 /* SheshBeshUITests.swift in Sources */,
+				AF2000000000000000000010 /* PRScreenshotsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SheshBesh/Shared/AppLaunchConfiguration.swift
+++ b/SheshBesh/Shared/AppLaunchConfiguration.swift
@@ -117,7 +117,6 @@ public enum AppLaunchConfiguration {
             let started = Date(timeIntervalSinceReferenceDate: Double(800_000_000 + index * 86_400))
             records.append(
                 MatchRecord(
-                    id: deterministicUUID(seed: "history-\(index)"),
                     rivalID: rival.id,
                     gameIndex: index,
                     userPlayed: .white,
@@ -136,7 +135,6 @@ public enum AppLaunchConfiguration {
             timeIntervalSinceReferenceDate: Double(800_000_000 + priorOutcomes.count * 86_400)
         )
         let finalRecord = MatchRecord(
-            id: UUID(uuidString: "9D4FBC2C-AB8B-4F6F-9F70-3A0F4F61C4A6")!,
             rivalID: rival.id,
             gameIndex: priorOutcomes.count,
             userPlayed: .white,
@@ -169,28 +167,6 @@ public enum AppLaunchConfiguration {
             backgroundMatchViewModel: backgroundViewModel,
             completedRecordPreview: finalRecord
         )
-    }
-
-    private static func deterministicUUID(seed: String) -> UUID {
-        var hash = UInt64(14_695_981_039_346_656_037)
-        for byte in seed.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 1_099_511_628_211
-        }
-        let high = hash
-        var low = hash
-        for byte in seed.utf8 {
-            low &*= 1_099_511_628_211
-            low ^= UInt64(byte)
-        }
-        let bytes: [UInt8] = (0..<8).map { UInt8(truncatingIfNeeded: high >> (8 * $0)) } +
-            (0..<8).map { UInt8(truncatingIfNeeded: low >> (8 * $0)) }
-        return UUID(uuid: (
-            bytes[0], bytes[1], bytes[2], bytes[3],
-            bytes[4], bytes[5], bytes[6], bytes[7],
-            bytes[8], bytes[9], bytes[10], bytes[11],
-            bytes[12], bytes[13], bytes[14], bytes[15]
-        ))
     }
 
     private static func scriptedDice(from arguments: [String]) -> [Int] {

--- a/SheshBesh/Shared/AppLaunchConfiguration.swift
+++ b/SheshBesh/Shared/AppLaunchConfiguration.swift
@@ -10,19 +10,16 @@ public enum AppLaunchConfiguration {
     @MainActor
     public static func rootView(arguments: [String] = ProcessInfo.processInfo.arguments) -> RootView {
         #if DEBUG
+        if let scene = uiTestScene(from: arguments) {
+            return scene.rootView(arguments: arguments)
+        }
+
         if arguments.contains("-uiTestingRootLedger") {
-            return RootView(coordinator: seededRootLedgerCoordinator())
+            return UITestScene.rivalriesHome.rootView(arguments: arguments)
         }
 
         if arguments.contains("-uiTesting") {
-            let dice = scriptedDice(from: arguments)
-            return RootView(
-                viewModel: MatchViewModel(
-                    engine: MatchEngine(diceRoller: ScriptedDiceRoller(dice)),
-                    config: .tournament(targetScore: 7),
-                    opponentDelay: {}
-                )
-            )
+            return UITestScene.boardOpening.rootView(arguments: arguments)
         }
         #else
         _ = arguments
@@ -41,6 +38,50 @@ public enum AppLaunchConfiguration {
     }
 
     #if DEBUG
+    /// Named scenes the UI test target can route to via `-uiTestScene <name>`.
+    /// Add a case here, implement `rootView(arguments:)`, and the new scene is
+    /// reachable from any UI test that launches the app.
+    public enum UITestScene: String, CaseIterable {
+        case boardOpening = "board-opening"
+        case rivalriesHome = "rivalries-home"
+        case matchEndYouWon = "match-end-you-won"
+        case matchEndRivalWon = "match-end-rival-won"
+
+        @MainActor
+        func rootView(arguments: [String]) -> RootView {
+            switch self {
+            case .boardOpening:
+                let dice = scriptedDice(from: arguments)
+                return RootView(
+                    viewModel: MatchViewModel(
+                        engine: MatchEngine(diceRoller: ScriptedDiceRoller(dice)),
+                        config: .tournament(targetScore: 7),
+                        opponentDelay: {}
+                    )
+                )
+
+            case .rivalriesHome:
+                return RootView(coordinator: seededRootLedgerCoordinator())
+
+            case .matchEndYouWon:
+                return matchEndRootView(winner: .you)
+
+            case .matchEndRivalWon:
+                return matchEndRootView(winner: .rival)
+            }
+        }
+    }
+
+    private static func uiTestScene(from arguments: [String]) -> UITestScene? {
+        guard
+            let flagIndex = arguments.firstIndex(of: "-uiTestScene"),
+            arguments.indices.contains(arguments.index(after: flagIndex))
+        else {
+            return nil
+        }
+        return UITestScene(rawValue: arguments[arguments.index(after: flagIndex)])
+    }
+
     @MainActor
     private static func seededRootLedgerCoordinator() -> LedgerCoordinator {
         let rival = Rival(
@@ -57,6 +98,99 @@ public enum AppLaunchConfiguration {
             lastUpdatedAt: Date(timeIntervalSinceReferenceDate: 800_000_200)
         )
         return LedgerCoordinator(store: InMemoryLedgerStore(rivals: [rival], activeMatches: [activeMatch]))
+    }
+
+    @MainActor
+    private static func matchEndRootView(winner: MatchOutcome) -> RootView {
+        let rival = Rival(
+            id: UUID(uuidString: "7C48FB94-F61B-4D71-BF7F-A181713381B4")!,
+            displayName: AIDifficulty.medium.rivalDisplayName,
+            createdAt: Date(timeIntervalSinceReferenceDate: 800_000_000)
+        )
+
+        let priorOutcomes: [MatchOutcome] = winner == .you
+            ? [.rival, .rival, .you, .you, .you]
+            : [.you, .you, .rival, .rival, .rival]
+
+        var records: [MatchRecord] = []
+        for (index, outcome) in priorOutcomes.enumerated() {
+            let started = Date(timeIntervalSinceReferenceDate: Double(800_000_000 + index * 86_400))
+            records.append(
+                MatchRecord(
+                    id: deterministicUUID(seed: "history-\(index)"),
+                    rivalID: rival.id,
+                    gameIndex: index,
+                    userPlayed: .white,
+                    winner: outcome,
+                    userScore: outcome == .you ? 7 : 4,
+                    rivalScore: outcome == .you ? 3 : 7,
+                    targetScore: 7,
+                    startedAt: started,
+                    completedAt: started.addingTimeInterval(1_800),
+                    finalSnapshot: nil
+                )
+            )
+        }
+
+        let finalStarted = Date(
+            timeIntervalSinceReferenceDate: Double(800_000_000 + priorOutcomes.count * 86_400)
+        )
+        let finalRecord = MatchRecord(
+            id: UUID(uuidString: "9D4FBC2C-AB8B-4F6F-9F70-3A0F4F61C4A6")!,
+            rivalID: rival.id,
+            gameIndex: priorOutcomes.count,
+            userPlayed: .white,
+            winner: winner,
+            userScore: winner == .you ? 7 : 4,
+            rivalScore: winner == .you ? 3 : 7,
+            targetScore: 7,
+            startedAt: finalStarted,
+            completedAt: finalStarted.addingTimeInterval(1_800),
+            finalSnapshot: nil
+        )
+        records.append(finalRecord)
+
+        let coordinator = LedgerCoordinator(
+            store: InMemoryLedgerStore(rivals: [rival], records: records)
+        )
+        coordinator.seedLedgersForUITests([
+            makeLedger(rival: rival, records: records, activeMatch: nil)
+        ])
+
+        let backgroundViewModel = MatchViewModel(
+            engine: MatchEngine(diceRoller: ScriptedDiceRoller([6, 1])),
+            config: .tournament(targetScore: 7),
+            opponentName: rival.displayName,
+            opponentDelay: {}
+        )
+
+        return RootView(
+            coordinator: coordinator,
+            backgroundMatchViewModel: backgroundViewModel,
+            completedRecordPreview: finalRecord
+        )
+    }
+
+    private static func deterministicUUID(seed: String) -> UUID {
+        var hash = UInt64(14_695_981_039_346_656_037)
+        for byte in seed.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        let high = hash
+        var low = hash
+        for byte in seed.utf8 {
+            low &*= 1_099_511_628_211
+            low ^= UInt64(byte)
+        }
+        let bytes: [UInt8] = (0..<8).map { UInt8(truncatingIfNeeded: high >> (8 * $0)) } +
+            (0..<8).map { UInt8(truncatingIfNeeded: low >> (8 * $0)) }
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 
     private static func scriptedDice(from arguments: [String]) -> [Int] {

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -140,6 +140,15 @@ public final class LedgerCoordinator {
         ledgers.first { $0.rival.id == rivalID }
     }
 
+    #if DEBUG
+    /// Synchronously seeds the cached ledgers. Used by UI test scenes to
+    /// surface views (like the match-end sheet) that read ledger data before
+    /// any async `refresh()` would normally complete.
+    public func seedLedgersForUITests(_ ledgers: [RivalLedger]) {
+        self.ledgers = ledgers
+    }
+    #endif
+
     public func rival(for rivalID: Rival.ID) -> Rival? {
         ledger(for: rivalID)?.rival
     }

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -48,6 +48,25 @@ public struct RootView: View {
         #endif
     }
 
+    #if DEBUG
+    /// Debug-only seam used by UI test scenes to surface the match-end sheet
+    /// over a posed board without playing a full match. The completed record
+    /// is presented immediately and the supplied view model renders behind it.
+    public init(
+        coordinator: LedgerCoordinator,
+        backgroundMatchViewModel: MatchViewModel,
+        completedRecordPreview: MatchRecord
+    ) {
+        _singleMatchViewModel = State(initialValue: nil)
+        _coordinator = State(initialValue: coordinator)
+        _activeMatchViewModel = State(initialValue: backgroundMatchViewModel)
+        _completedRecord = State(initialValue: completedRecordPreview)
+        #if canImport(GameKit) && canImport(UIKit)
+        _gameCenterMatchCoordinator = State(initialValue: GameCenterMatchCoordinator(ledgerCoordinator: coordinator))
+        #endif
+    }
+    #endif
+
     public var body: some View {
         Group {
             if let singleMatchViewModel {

--- a/SheshBeshUITests/PRScreenshotsTests.swift
+++ b/SheshBeshUITests/PRScreenshotsTests.swift
@@ -31,7 +31,7 @@ final class PRScreenshotsTests: XCTestCase {
         attachScreenshot(named: "board-opening-pre-roll")
 
         app.buttons["action-opening-roll"].tap()
-        XCTAssertTrue(element("die-1", in: app).waitForExistence(timeout: 2))
+        XCTAssertTrue(element("die-1", in: app).waitForExistence(timeout: 5))
         attachScreenshot(named: "board-opening-rolled-6-1")
 
         element("point-24", in: app).tap()

--- a/SheshBeshUITests/PRScreenshotsTests.swift
+++ b/SheshBeshUITests/PRScreenshotsTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+
+/// One method per "scene" the PR screenshot pipeline can capture.
+///
+/// To add a new scene:
+///   1. Add a case to `AppLaunchConfiguration.UITestScene` and implement its
+///      `rootView(arguments:)` so the app launches directly into the desired
+///      surface.
+///   2. Add a `testCapture_<SceneName>` method here that launches with that
+///      scene and attaches a screenshot named the same as the scene's raw
+///      value.
+///   3. Add the scene name to the SCREENSHOT_SCENE_TESTS map in
+///      `scripts/capture-pr-screenshots.sh`.
+///
+/// `scripts/capture-pr-screenshots.sh` runs every method in this class by
+/// default. Pass `PR_SCREENSHOT_SCENES=board-opening,match-end-you-won` to
+/// run a subset.
+final class PRScreenshotsTests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    // MARK: Scenes
+
+    @MainActor
+    func testCapture_BoardOpening() throws {
+        let app = sceneApp("board-opening", extraArguments: ["-uiTestDice", "6,1,6,1"])
+        app.launch()
+
+        XCTAssertTrue(app.buttons["action-opening-roll"].waitForExistence(timeout: 5))
+        attachScreenshot(named: "board-opening-pre-roll")
+
+        app.buttons["action-opening-roll"].tap()
+        XCTAssertTrue(element("die-1", in: app).waitForExistence(timeout: 2))
+        attachScreenshot(named: "board-opening-rolled-6-1")
+
+        element("point-24", in: app).tap()
+        element("point-18", in: app).tap()
+        element("point-24", in: app).tap()
+        element("point-23", in: app).tap()
+        app.buttons["action-submit-turn"].tap()
+
+        XCTAssertTrue(app.buttons["action-roll-dice"].waitForExistence(timeout: 4))
+        attachScreenshot(named: "board-opening-after-first-turn")
+    }
+
+    @MainActor
+    func testCapture_RivalriesHome() throws {
+        let app = sceneApp("rivalries-home")
+        app.launch()
+
+        XCTAssertTrue(app.buttons["home-new-ai-rival"].waitForExistence(timeout: 5))
+        attachScreenshot(named: "rivalries-home")
+    }
+
+    @MainActor
+    func testCapture_MatchEndYouWon() throws {
+        let app = sceneApp("match-end-you-won")
+        app.launch()
+        captureMatchEndSheet(in: app, named: "match-end-you-won")
+    }
+
+    @MainActor
+    func testCapture_MatchEndRivalWon() throws {
+        let app = sceneApp("match-end-rival-won")
+        app.launch()
+        captureMatchEndSheet(in: app, named: "match-end-rival-won")
+    }
+
+    // MARK: Helpers
+
+    @MainActor
+    private func sceneApp(_ scene: String, extraArguments: [String] = []) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uiTestScene", scene] + extraArguments
+        return app
+    }
+
+    @MainActor
+    private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)[identifier]
+    }
+
+    @MainActor
+    private func captureMatchEndSheet(in app: XCUIApplication, named name: String) {
+        // The match-end sheet presents over the board. Wait for its dismiss
+        // button so we know it is fully laid out before grabbing the frame.
+        let dismiss = app.buttons.matching(identifier: "Back home").firstMatch
+        XCTAssertTrue(
+            dismiss.waitForExistence(timeout: 6),
+            "Match-end sheet did not appear within 6s for scene named \(name)"
+        )
+        attachScreenshot(named: name)
+    }
+
+    @MainActor
+    private func attachScreenshot(named name: String) {
+        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/SheshBeshUITests/SheshBeshUITests.swift
+++ b/SheshBeshUITests/SheshBeshUITests.swift
@@ -45,28 +45,6 @@ final class SheshBeshUITests: XCTestCase {
     }
 
     @MainActor
-    func testPRScreenshots() throws {
-        let app = configuredApp()
-        app.launch()
-
-        XCTAssertTrue(app.buttons["action-opening-roll"].waitForExistence(timeout: 5))
-        attachScreenshot(named: "01-opening-roll")
-
-        app.buttons["action-opening-roll"].tap()
-        XCTAssertTrue(element("die-1", in: app).waitForExistence(timeout: 2))
-        attachScreenshot(named: "02-rolled-6-1")
-
-        element("point-24", in: app).tap()
-        element("point-18", in: app).tap()
-        element("point-24", in: app).tap()
-        element("point-23", in: app).tap()
-        app.buttons["action-submit-turn"].tap()
-
-        XCTAssertTrue(app.buttons["action-roll-dice"].waitForExistence(timeout: 4))
-        attachScreenshot(named: "03-your-turn")
-    }
-
-    @MainActor
     func testRootRivalryButtonsDoNotRenderSystemBlueIcons() throws {
         let app = rootLedgerApp()
         app.launch()
@@ -123,14 +101,6 @@ final class SheshBeshUITests: XCTestCase {
     @MainActor
     private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
         app.descendants(matching: .any)[identifier]
-    }
-
-    @MainActor
-    private func attachScreenshot(named name: String) {
-        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
-        attachment.name = name
-        attachment.lifetime = .keepAlways
-        add(attachment)
     }
 
     @MainActor

--- a/scripts/capture-pr-screenshots.sh
+++ b/scripts/capture-pr-screenshots.sh
@@ -9,6 +9,38 @@ SCREENSHOT_DIR="${SCREENSHOT_DIR:-$ROOT_DIR/.context/pr-screenshots}"
 RESULT_BUNDLE_PATH="${RESULT_BUNDLE_PATH:-$ROOT_DIR/.context/pr-screenshots.xcresult}"
 ATTACHMENTS_DIR="$SCREENSHOT_DIR/.xcresult-attachments"
 
+# Map scene names (from AppLaunchConfiguration.UITestScene) to the UI test
+# method name in PRScreenshotsTests. Keep this in sync with that file —
+# adding a new scene means adding both a test method and a case here.
+SCENE_NAMES="board-opening rivalries-home match-end-you-won match-end-rival-won"
+test_name_for_scene() {
+  case "$1" in
+    board-opening)        echo testCapture_BoardOpening ;;
+    rivalries-home)       echo testCapture_RivalriesHome ;;
+    match-end-you-won)    echo testCapture_MatchEndYouWon ;;
+    match-end-rival-won)  echo testCapture_MatchEndRivalWon ;;
+    *)                    return 1 ;;
+  esac
+}
+
+# Build the -only-testing flags. PR_SCREENSHOT_SCENES, when set, is a
+# comma-separated subset of scene names; unset means run them all.
+only_testing_flags=()
+if [[ -n "${PR_SCREENSHOT_SCENES:-}" ]]; then
+  IFS=',' read -r -a requested_scenes <<<"$PR_SCREENSHOT_SCENES"
+  for scene in "${requested_scenes[@]}"; do
+    scene="${scene//[[:space:]]/}"
+    [[ -z "$scene" ]] && continue
+    if ! test_name=$(test_name_for_scene "$scene"); then
+      echo "Unknown scene: $scene. Known scenes: $SCENE_NAMES" >&2
+      exit 1
+    fi
+    only_testing_flags+=("-only-testing:SheshBeshUITests/PRScreenshotsTests/$test_name")
+  done
+else
+  only_testing_flags+=("-only-testing:SheshBeshUITests/PRScreenshotsTests")
+fi
+
 rm -rf "$SCREENSHOT_DIR" "$RESULT_BUNDLE_PATH"
 mkdir -p "$ATTACHMENTS_DIR"
 
@@ -16,7 +48,7 @@ xcodebuild \
   -project SheshBesh.xcodeproj \
   -scheme SheshBesh \
   -destination "$IOS_TEST_DESTINATION" \
-  -only-testing:SheshBeshUITests/SheshBeshUITests/testPRScreenshots \
+  "${only_testing_flags[@]}" \
   -resultBundlePath "$RESULT_BUNDLE_PATH" \
   CODE_SIGNING_ALLOWED=NO \
   test


### PR DESCRIPTION
## Summary

The deterministic screenshot pipeline used to be a single hardcoded flow through the in-game board. Anything outside that one flow (rivalries home, match-end sheet, double-offer, splash, etc.) was effectively uncoverable — running the script for those PRs produced board PNGs that didn't show the change. This PR turns the pipeline into a registry of named scenes you can pick from.

**Scenes (extensible)**
| Scene | What it captures | Output |
|---|---|---|
| `board-opening` | Pre-roll, rolled 6-1, after-first-turn | 3 PNGs |
| `rivalries-home` | Seeded home with one AI rival and a resumable match | 1 PNG |
| `match-end-you-won` | Match-end sheet over the board, "You won 7-3", streak: YOU 4 | 1 PNG |
| `match-end-rival-won` | Same sheet, "Medium AI won 7-4", streak: Medium AI 4 | 1 PNG |

**Plumbing**
- `AppLaunchConfiguration.UITestScene` enum dispatches `-uiTestScene <name>`. Adding a scene is one enum case, one `testCapture_*` method, one row in the script.
- `RootView` got a debug-only init that pre-seeds `activeMatchViewModel` + `completedRecord` so the match-end sheet renders immediately over a posed board — no playing through a full match in the test.
- `LedgerCoordinator.seedLedgersForUITests([...])` synchronously populates the cached ledgers so the sheet's win counts and streak appear without an async refresh.
- `-uiTesting` and `-uiTestingRootLedger` are now thin aliases for `board-opening` / `rivalries-home` — existing smoke tests still pass unchanged.

**Selection**
```bash
PR_SCREENSHOT_SCENES=match-end-you-won,match-end-rival-won ./scripts/capture-pr-screenshots.sh
```
Unset = all scenes. Unknown scene name exits with the list of known names. Bash-3.2 compatible (no associative arrays).

**Skill**
Project-local `.claude/skills/pr-screenshots/` ships alongside the pipeline with a file-to-scene classification table so an agent can pick the right subset of scenes from a diff (e.g., a `MatchEndSheet.swift` change runs both match-end variants, an engine-only diff runs nothing).

## Test plan
- [x] `swift test` — engine + ledger packages pass
- [x] `xcodebuild -only-testing:SheshBeshUITests/SheshBeshUITests test` — the three pre-existing smoke tests pass unchanged (they rely on `-uiTesting` and `-uiTestingRootLedger` aliasing through to the new scenes)
- [x] `./scripts/capture-pr-screenshots.sh` with no `PR_SCREENSHOT_SCENES` env var — all 4 scenes run, 6 PNGs exported (3 board frames + 3 single frames)
- [x] `PR_SCREENSHOT_SCENES=match-end-you-won,match-end-rival-won ./scripts/capture-pr-screenshots.sh` — only the 2 selected scenes run, 2 PNGs exported, ledger numbers and streaks render correctly on both variants
- [x] `PR_SCREENSHOT_SCENES=does-not-exist ./scripts/capture-pr-screenshots.sh` — exits non-zero with the list of known scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)