### PR TITLE
Fix unresolved Game Center rivalries

### DIFF
--- a/SheshBesh/Shared/GameCenterEnvelope.swift
+++ b/SheshBesh/Shared/GameCenterEnvelope.swift
@@ -3,6 +3,8 @@ import Foundation
 import SheshBeshGame
 
 public struct GameCenterPlayerMapping: Codable, Equatable, Hashable, Sendable {
+    static let pendingPlayerIDPrefix = "pending-"
+
     public var whitePlayerID: String
     public var blackPlayerID: String
     public var whiteDisplayName: String
@@ -42,6 +44,14 @@ public struct GameCenterPlayerMapping: Codable, Equatable, Hashable, Sendable {
         case .black:
             blackDisplayName
         }
+    }
+
+    func hasPendingGameCenterID(for player: Player) -> Bool {
+        Self.isPendingGameCenterID(gameCenterID(for: player))
+    }
+
+    static func isPendingGameCenterID(_ playerID: String) -> Bool {
+        playerID.hasPrefix(pendingPlayerIDPrefix)
     }
 }
 

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -369,8 +369,6 @@ public final class GameCenterMatchCoordinator {
         envelope: GameCenterMatchEnvelope,
         localPlayerID: String
     ) async throws -> GameCenterLoadedMatch {
-        await ledgerCoordinator.refresh()
-
         let localPlayer = envelope.playerMapping.player(forGameCenterID: localPlayerID) ?? .white
         let opponent = localPlayer.opponent
         let opponentID = envelope.playerMapping.gameCenterID(for: opponent)

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -383,8 +383,11 @@ public final class GameCenterMatchCoordinator {
                 gameCenterPlayerID: opponentID,
                 gameCenterDisplayName: opponentName
             )
+        let activeMatchID = existingActive?.id ?? (
+            isOpponentResolved ? UUID() : Self.transientActiveMatchID(for: match.matchID)
+        )
         let activeMatch = ActiveMatch(
-            id: existingActive?.id ?? UUID(),
+            id: activeMatchID,
             rivalID: rival.id,
             gameCenterMatchID: match.matchID,
             gameIndex: envelope.gameIndex,
@@ -488,6 +491,21 @@ public final class GameCenterMatchCoordinator {
             config: config,
             state: MatchEngine.newMatch(config: config)
         )
+    }
+
+    static func transientActiveMatchID(for gameCenterMatchID: String) -> UUID {
+        let high = GameCenterDiceRoller.stableHash("transient-active-match:\(gameCenterMatchID):high")
+        let low = GameCenterDiceRoller.stableHash("transient-active-match:\(gameCenterMatchID):low")
+        var bytes = high.bigEndianBytes + low.bigEndianBytes
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 
     private static func resolvingParticipants(
@@ -1108,5 +1126,11 @@ private struct EmptyGameCenterLedgerView: View {
 private struct AuthenticationController: Identifiable {
     let viewController: UIViewController
     var id: ObjectIdentifier { ObjectIdentifier(viewController) }
+}
+
+private extension UInt64 {
+    var bigEndianBytes: [UInt8] {
+        withUnsafeBytes(of: bigEndian) { Array($0) }
+    }
 }
 #endif

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -275,7 +275,9 @@ public final class GameCenterMatchCoordinator {
                 localPlayerID: localPlayerID,
                 targetScore: targetScore
             )
-            if match.currentParticipant?.player?.gamePlayerID == localPlayerID {
+            if match.currentParticipant?.player?.gamePlayerID == localPlayerID,
+               !envelope.playerMapping.hasPendingGameCenterID(for: .white),
+               !envelope.playerMapping.hasPendingGameCenterID(for: .black) {
                 try await save(envelope: envelope, to: match)
             }
         }
@@ -373,14 +375,21 @@ public final class GameCenterMatchCoordinator {
         let opponent = localPlayer.opponent
         let opponentID = envelope.playerMapping.gameCenterID(for: opponent)
         let opponentName = envelope.playerMapping.displayName(for: opponent)
-
-        let rival = ledgerCoordinator.rival(matchingGameCenterPlayerID: opponentID)
-            ?? Rival(
+        let isOpponentResolved = !GameCenterPlayerMapping.isPendingGameCenterID(opponentID)
+        let existingActive = isOpponentResolved
+            ? ledgerCoordinator.activeMatch(gameCenterMatchID: match.matchID)
+            : nil
+        let rival = isOpponentResolved
+            ? ledgerCoordinator.rival(matchingGameCenterPlayerID: opponentID) ?? Rival(
                 displayName: opponentName,
                 gameCenterPlayerID: opponentID,
                 gameCenterDisplayName: opponentName
             )
-        let existingActive = ledgerCoordinator.activeMatch(gameCenterMatchID: match.matchID)
+            : Rival(
+                displayName: opponentName,
+                gameCenterPlayerID: opponentID,
+                gameCenterDisplayName: opponentName
+            )
         let activeMatch = ActiveMatch(
             id: existingActive?.id ?? UUID(),
             rivalID: rival.id,
@@ -392,7 +401,9 @@ public final class GameCenterMatchCoordinator {
             lastUpdatedAt: Date()
         )
 
-        try await ledgerCoordinator.saveGameCenterMatch(activeMatch, rival: rival)
+        if isOpponentResolved {
+            try await ledgerCoordinator.saveGameCenterMatch(activeMatch, rival: rival)
+        }
 
         return GameCenterLoadedMatch(
             match: match,
@@ -469,7 +480,7 @@ public final class GameCenterMatchCoordinator {
             guard let playerID = participant.player?.gamePlayerID else { return false }
             return playerID != localPlayerID
         }
-        let opponentID = opponent?.player?.gamePlayerID ?? "pending-\(match.matchID)"
+        let opponentID = opponent?.player?.gamePlayerID ?? "\(GameCenterPlayerMapping.pendingPlayerIDPrefix)\(match.matchID)"
         let opponentName = opponent?.player?.displayName ?? "Opponent"
         let config = MatchConfig.tournament(targetScore: targetScore)
 

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -377,13 +377,8 @@ public final class GameCenterMatchCoordinator {
         let existingActive = isOpponentResolved
             ? ledgerCoordinator.activeMatch(gameCenterMatchID: match.matchID)
             : nil
-        let rival = isOpponentResolved
-            ? ledgerCoordinator.rival(matchingGameCenterPlayerID: opponentID) ?? Rival(
-                displayName: opponentName,
-                gameCenterPlayerID: opponentID,
-                gameCenterDisplayName: opponentName
-            )
-            : Rival(
+        let rival = (isOpponentResolved ? ledgerCoordinator.rival(matchingGameCenterPlayerID: opponentID) : nil)
+            ?? Rival(
                 displayName: opponentName,
                 gameCenterPlayerID: opponentID,
                 gameCenterDisplayName: opponentName

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -194,9 +194,7 @@ public final class LedgerCoordinator {
 
     private func reconciledSnapshot() async throws -> LedgerSnapshot {
         var snapshot = try await store.loadAllLedgerData()
-        if try await purgePendingGameCenterRivals(in: snapshot) {
-            snapshot = try await store.loadAllLedgerData()
-        }
+        snapshot = try await purgingPendingGameCenterRivals(in: snapshot)
 
         let completedMatches = snapshot.activeMatchesByRival.values.filter { $0.state.completion != nil }
         guard !completedMatches.isEmpty else { return snapshot }
@@ -210,21 +208,29 @@ public final class LedgerCoordinator {
         return try await store.loadAllLedgerData()
     }
 
-    private func purgePendingGameCenterRivals(in snapshot: LedgerSnapshot) async throws -> Bool {
-        var didChange = false
+    private func purgingPendingGameCenterRivals(in snapshot: LedgerSnapshot) async throws -> LedgerSnapshot {
+        var rivals = snapshot.rivals
+        var recordsByRival = snapshot.recordsByRival
+        var activeMatchesByRival = snapshot.activeMatchesByRival
 
         for rival in snapshot.rivals where Self.isPendingGameCenterRival(rival) {
             let records = snapshot.recordsByRival[rival.id, default: []]
             guard records.isEmpty else { continue }
 
-            if snapshot.activeMatchesByRival[rival.id] != nil {
+            if activeMatchesByRival[rival.id] != nil {
                 try await store.clearActiveMatch(rivalID: rival.id)
+                activeMatchesByRival[rival.id] = nil
             }
             try await store.deleteRival(id: rival.id)
-            didChange = true
+            rivals.removeAll { $0.id == rival.id }
+            recordsByRival[rival.id] = nil
         }
 
-        return didChange
+        return LedgerSnapshot(
+            rivals: rivals,
+            recordsByRival: recordsByRival,
+            activeMatchesByRival: activeMatchesByRival
+        )
     }
 
     private func makeRecord(from match: ActiveMatch, completedAt: Date) throws -> MatchRecord {

--- a/SheshBesh/Shared/LedgerCoordinator.swift
+++ b/SheshBesh/Shared/LedgerCoordinator.swift
@@ -178,6 +178,11 @@ public final class LedgerCoordinator {
         rival.gameCenterPlayerID == nil && rival.displayName == difficulty.rivalDisplayName
     }
 
+    private static func isPendingGameCenterRival(_ rival: Rival) -> Bool {
+        guard let gameCenterPlayerID = rival.gameCenterPlayerID else { return false }
+        return GameCenterPlayerMapping.isPendingGameCenterID(gameCenterPlayerID)
+    }
+
     private static func sortLedgers(_ lhs: RivalLedger, _ rhs: RivalLedger) -> Bool {
         let lhsDate = lhs.lastPlayedAt ?? lhs.activeMatch?.lastUpdatedAt ?? lhs.rival.createdAt
         let rhsDate = rhs.lastPlayedAt ?? rhs.activeMatch?.lastUpdatedAt ?? rhs.rival.createdAt
@@ -188,7 +193,11 @@ public final class LedgerCoordinator {
     }
 
     private func reconciledSnapshot() async throws -> LedgerSnapshot {
-        let snapshot = try await store.loadAllLedgerData()
+        var snapshot = try await store.loadAllLedgerData()
+        if try await purgePendingGameCenterRivals(in: snapshot) {
+            snapshot = try await store.loadAllLedgerData()
+        }
+
         let completedMatches = snapshot.activeMatchesByRival.values.filter { $0.state.completion != nil }
         guard !completedMatches.isEmpty else { return snapshot }
 
@@ -199,6 +208,23 @@ public final class LedgerCoordinator {
         }
 
         return try await store.loadAllLedgerData()
+    }
+
+    private func purgePendingGameCenterRivals(in snapshot: LedgerSnapshot) async throws -> Bool {
+        var didChange = false
+
+        for rival in snapshot.rivals where Self.isPendingGameCenterRival(rival) {
+            let records = snapshot.recordsByRival[rival.id, default: []]
+            guard records.isEmpty else { continue }
+
+            if snapshot.activeMatchesByRival[rival.id] != nil {
+                try await store.clearActiveMatch(rivalID: rival.id)
+            }
+            try await store.deleteRival(id: rival.id)
+            didChange = true
+        }
+
+        return didChange
     }
 
     private func makeRecord(from match: ActiveMatch, completedAt: Date) throws -> MatchRecord {

--- a/SheshBeshTests/GameCenterEnvelopeTests.swift
+++ b/SheshBeshTests/GameCenterEnvelopeTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SheshBeshApp
+@testable import SheshBeshApp
 import SheshBeshGame
 import Testing
 
@@ -64,5 +64,20 @@ struct GameCenterEnvelopeTests {
         let rolls = (0..<6).map { _ in roller.rollDie() }
 
         #expect(rolls == [5, 4, 4, 6, 4, 2])
+    }
+
+    @Test("pending Game Center IDs are identified as unresolved participants")
+    func pendingGameCenterIDsAreUnresolvedParticipants() {
+        let mapping = GameCenterPlayerMapping(
+            whitePlayerID: "local-player",
+            blackPlayerID: "pending-match-123",
+            whiteDisplayName: "Boris",
+            blackDisplayName: "Opponent"
+        )
+
+        #expect(mapping.hasPendingGameCenterID(for: .black))
+        #expect(!mapping.hasPendingGameCenterID(for: .white))
+        #expect(GameCenterPlayerMapping.isPendingGameCenterID("pending-match-123"))
+        #expect(!GameCenterPlayerMapping.isPendingGameCenterID("real-player"))
     }
 }

--- a/SheshBeshTests/GameCenterEnvelopeTests.swift
+++ b/SheshBeshTests/GameCenterEnvelopeTests.swift
@@ -80,4 +80,16 @@ struct GameCenterEnvelopeTests {
         #expect(GameCenterPlayerMapping.isPendingGameCenterID("pending-match-123"))
         #expect(!GameCenterPlayerMapping.isPendingGameCenterID("real-player"))
     }
+
+    #if canImport(GameKit) && canImport(UIKit)
+    @Test("transient Game Center active match IDs are stable")
+    func transientGameCenterActiveMatchIDsAreStable() {
+        let firstID = GameCenterMatchCoordinator.transientActiveMatchID(for: "gc-match-1")
+        let secondID = GameCenterMatchCoordinator.transientActiveMatchID(for: "gc-match-1")
+        let otherID = GameCenterMatchCoordinator.transientActiveMatchID(for: "gc-match-2")
+
+        #expect(firstID == secondID)
+        #expect(firstID != otherID)
+    }
+    #endif
 }

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -313,6 +313,54 @@ struct LedgerCoordinatorTests {
         #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
         #expect(coordinator.ledger(for: rival.id) == nil)
     }
+
+    @Test("refresh purges pending Game Center placeholder rivalries")
+    @MainActor
+    func refreshPurgesPendingGameCenterPlaceholderRivalries() async throws {
+        let rival = Rival(
+            displayName: "Opponent",
+            gameCenterPlayerID: "pending-gc-match-1",
+            gameCenterDisplayName: "Opponent"
+        )
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            gameCenterMatchID: "gc-match-1",
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        )
+        let store = InMemoryLedgerStore(rivals: [rival], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+
+        #expect(try await store.loadRivals().isEmpty)
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == nil)
+        #expect(coordinator.ledgers.isEmpty)
+    }
+
+    @Test("refresh preserves resolved Game Center rival named Opponent")
+    @MainActor
+    func refreshPreservesResolvedGameCenterRivalNamedOpponent() async throws {
+        let rival = Rival(
+            displayName: "Opponent",
+            gameCenterPlayerID: "real-game-center-player",
+            gameCenterDisplayName: "Opponent"
+        )
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            gameCenterMatchID: "gc-match-1",
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        )
+        let store = InMemoryLedgerStore(rivals: [rival], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+
+        #expect(try await store.loadRivals() == [rival])
+        #expect(try await store.loadActiveMatch(rivalID: rival.id) == active)
+        #expect(coordinator.ledger(for: rival.id)?.activeMatch == active)
+    }
 }
 
 private final class CompletionDiceRoller: DiceRolling, @unchecked Sendable {

--- a/SheshBeshTests/LedgerCoordinatorTests.swift
+++ b/SheshBeshTests/LedgerCoordinatorTests.swift
@@ -338,6 +338,29 @@ struct LedgerCoordinatorTests {
         #expect(coordinator.ledgers.isEmpty)
     }
 
+    @Test("refresh reuses the snapshot after purging pending Game Center placeholders")
+    @MainActor
+    func refreshReusesSnapshotAfterPurgingPendingGameCenterPlaceholders() async throws {
+        let rival = Rival(
+            displayName: "Opponent",
+            gameCenterPlayerID: "pending-gc-match-1",
+            gameCenterDisplayName: "Opponent"
+        )
+        let active = ActiveMatch(
+            rivalID: rival.id,
+            gameCenterMatchID: "gc-match-1",
+            userPlayed: .white,
+            state: MatchEngine.newMatch(config: .tournament(targetScore: 7))
+        )
+        let store = CountingLedgerStore(rivals: [rival], activeMatches: [active])
+        let coordinator = LedgerCoordinator(store: store)
+
+        await coordinator.refresh()
+
+        #expect(await store.loadAllLedgerDataCount == 1)
+        #expect(coordinator.ledgers.isEmpty)
+    }
+
     @Test("refresh preserves resolved Game Center rival named Opponent")
     @MainActor
     func refreshPreservesResolvedGameCenterRivalNamedOpponent() async throws {
@@ -360,6 +383,64 @@ struct LedgerCoordinatorTests {
         #expect(try await store.loadRivals() == [rival])
         #expect(try await store.loadActiveMatch(rivalID: rival.id) == active)
         #expect(coordinator.ledger(for: rival.id)?.activeMatch == active)
+    }
+}
+
+private actor CountingLedgerStore: LedgerStore {
+    private let store: InMemoryLedgerStore
+    private(set) var loadAllLedgerDataCount = 0
+
+    init(
+        rivals: [Rival] = [],
+        records: [MatchRecord] = [],
+        activeMatches: [ActiveMatch] = []
+    ) {
+        self.store = InMemoryLedgerStore(
+            rivals: rivals,
+            records: records,
+            activeMatches: activeMatches
+        )
+    }
+
+    func loadRivals() async throws -> [Rival] {
+        try await store.loadRivals()
+    }
+
+    func upsertRival(_ rival: Rival) async throws {
+        try await store.upsertRival(rival)
+    }
+
+    func deleteRival(id: Rival.ID) async throws {
+        try await store.deleteRival(id: id)
+    }
+
+    func loadMatchRecords(rivalID: Rival.ID) async throws -> [MatchRecord] {
+        try await store.loadMatchRecords(rivalID: rivalID)
+    }
+
+    func appendMatchRecord(_ record: MatchRecord) async throws {
+        try await store.appendMatchRecord(record)
+    }
+
+    func deleteMatchRecords(rivalID: Rival.ID) async throws {
+        try await store.deleteMatchRecords(rivalID: rivalID)
+    }
+
+    func loadActiveMatch(rivalID: Rival.ID) async throws -> ActiveMatch? {
+        try await store.loadActiveMatch(rivalID: rivalID)
+    }
+
+    func saveActiveMatch(_ match: ActiveMatch) async throws {
+        try await store.saveActiveMatch(match)
+    }
+
+    func clearActiveMatch(rivalID: Rival.ID) async throws {
+        try await store.clearActiveMatch(rivalID: rivalID)
+    }
+
+    func loadAllLedgerData() async throws -> LedgerSnapshot {
+        loadAllLedgerDataCount += 1
+        return try await store.loadAllLedgerData()
     }
 }
 


### PR DESCRIPTION
Unresolved Game Center participants now stay transient instead of being saved as Rivalries with the synthetic pending ID and "Opponent" display name. Ledger refresh also removes previously persisted pending Game Center placeholder rivalries that have no completed history, while preserving a real resolved player named Opponent. Added regression tests for pending ID detection, placeholder cleanup, and resolved-opponent preservation.\n\nTests: `swift test`; `xcodebuild -project SheshBesh.xcodeproj -scheme SheshBesh -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`.