### PR TITLE
Clean up legacy Gammonade names

### DIFF
--- a/.claude/skills/pr-screenshots/SKILL.md
+++ b/.claude/skills/pr-screenshots/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pr-screenshots
-description: Capture relevant iOS simulator screenshots for a shesh-besh PR before opening it. Inspects the staged/unstaged diff (and the diff vs main if on a branch), figures out which named scenes are actually affected, runs only those scenes from the deterministic XCUITest screenshot pipeline, and surfaces the resulting image paths so they can be referenced in the PR body. Use this whenever you are about to create or update a PR in this repo, whenever the user says "ship", "open a PR", "create a PR", or asks for screenshots, before-and-afters, or visual evidence of a change. Also use proactively when the user has finished work on the iOS app (anything under SheshBesh/) and is moving toward landing it. Skip when the diff is purely engine/ledger/tests/docs with no UI surface touched.
+description: Capture relevant iOS simulator screenshots for a Gammonade PR before opening it. Inspects the staged/unstaged diff (and the diff vs main if on a branch), figures out which named scenes are actually affected, runs only those scenes from the deterministic XCUITest screenshot pipeline, and surfaces the resulting image paths so they can be referenced in the PR body. Use this whenever you are about to create or update a PR in this repo, whenever the user says "ship", "open a PR", "create a PR", or asks for screenshots, before-and-afters, or visual evidence of a change. Also use proactively when the user has finished work on the iOS app (anything under SheshBesh/) and is moving toward landing it. Skip when the diff is purely engine/ledger/tests/docs with no UI surface touched.
 ---
 
 # pr-screenshots
 
-A skill for the shesh-besh iOS app. The repo ships a scene-based screenshot pipeline:
+A skill for the Gammonade iOS app. The repo ships a scene-based screenshot pipeline:
 
 - `SheshBeshUITests/PRScreenshotsTests.swift` — one `testCapture_<SceneName>` method per named scene. Each launches the app with `-uiTestScene <name>` and attaches one or more screenshots.
 - `SheshBesh/Shared/AppLaunchConfiguration.swift` — defines the `UITestScene` enum and seeds the right state for each scene (deterministic dice for the board, in-memory ledger for the rivalries home, pre-completed records for match-end sheets, and so on).

--- a/.claude/skills/pr-screenshots/evals/evals.json
+++ b/.claude/skills/pr-screenshots/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "name": "board-tweak",
-      "prompt": "I just finished tightening up the spacing at the top of the in-game board view (BoardView.swift, the VStack right under the linen background). I'm about to open a PR for this on shesh-besh — handle screenshots first please.",
+      "prompt": "I just finished tightening up the spacing at the top of the in-game board view (BoardView.swift, the VStack right under the linen background). I'm about to open a PR for this on Gammonade — handle screenshots first please.",
       "expected_output": "Skill identifies BoardView.swift as a covered surface, runs scripts/capture-pr-screenshots.sh, and reports the captured PNG paths. Should NOT skip and should NOT flag a coverage gap.",
       "files": []
     },

--- a/Packages/SheshBeshLedger/Sources/SheshBeshLedger/JSONLedgerStore.swift
+++ b/Packages/SheshBeshLedger/Sources/SheshBeshLedger/JSONLedgerStore.swift
@@ -12,19 +12,22 @@ public actor JSONLedgerStore: LedgerStore {
     }
 
     public static func defaultFileURL(
-        applicationName: String = "SheshBesh",
-        fileManager: FileManager = .default
+        applicationName: String = "Gammonade",
+        fileManager: FileManager = .default,
+        applicationSupportURL: URL? = nil
     ) throws -> URL {
-        guard let applicationSupportURL = fileManager.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first else {
-            throw CocoaError(.fileNoSuchFile)
-        }
-
-        return applicationSupportURL
+        let applicationSupportURL = try applicationSupportURL ?? defaultApplicationSupportURL(fileManager: fileManager)
+        let fileURL = applicationSupportURL
             .appendingPathComponent(applicationName, isDirectory: true)
             .appendingPathComponent("ledger.json")
+
+        try migrateLegacyLedgerIfNeeded(
+            to: fileURL,
+            applicationSupportURL: applicationSupportURL,
+            fileManager: fileManager
+        )
+
+        return fileURL
     }
 
     public func loadRivals() async throws -> [Rival] {
@@ -116,6 +119,40 @@ public actor JSONLedgerStore: LedgerStore {
         return decoded
     }
 
+    private static func defaultApplicationSupportURL(fileManager: FileManager) throws -> URL {
+        guard let applicationSupportURL = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return applicationSupportURL
+    }
+
+    private static func migrateLegacyLedgerIfNeeded(
+        to fileURL: URL,
+        applicationSupportURL: URL,
+        fileManager: FileManager
+    ) throws {
+        guard !fileManager.fileExists(atPath: fileURL.path) else { return }
+
+        let legacyFileURL = applicationSupportURL
+            .appendingPathComponent("SheshBesh", isDirectory: true)
+            .appendingPathComponent("ledger.json")
+        guard fileManager.fileExists(atPath: legacyFileURL.path) else { return }
+
+        try fileManager.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.moveItem(at: legacyFileURL, to: fileURL)
+
+        let legacyDirectoryURL = legacyFileURL.deletingLastPathComponent()
+        if let remainingItems = try? fileManager.contentsOfDirectory(atPath: legacyDirectoryURL.path),
+           remainingItems.isEmpty {
+            try? fileManager.removeItem(at: legacyDirectoryURL)
+        }
+    }
 }
 
 private struct PersistedSnapshot: Codable, Equatable, Sendable {

--- a/Packages/SheshBeshLedger/Tests/SheshBeshLedgerTests/JSONLedgerStoreTests.swift
+++ b/Packages/SheshBeshLedger/Tests/SheshBeshLedgerTests/JSONLedgerStoreTests.swift
@@ -89,4 +89,58 @@ struct JSONLedgerStoreTests {
         #expect(try await reader.loadMatchRecords(rivalID: firstRival.id).isEmpty)
         #expect(try await reader.loadMatchRecords(rivalID: secondRival.id) == [secondRecord])
     }
+
+    @Test("default file URL migrates legacy app support ledger")
+    func defaultFileURLMigratesLegacyLedger() async throws {
+        let fileManager = FileManager.default
+        let applicationSupportURL = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let legacyDirectoryURL = applicationSupportURL.appendingPathComponent("SheshBesh", isDirectory: true)
+        let legacyFileURL = legacyDirectoryURL.appendingPathComponent("ledger.json")
+        defer {
+            try? fileManager.removeItem(at: applicationSupportURL)
+        }
+
+        try fileManager.createDirectory(at: legacyDirectoryURL, withIntermediateDirectories: true)
+        let rival = Rival(displayName: "Dan")
+        let writer = try JSONLedgerStore(fileURL: legacyFileURL)
+        try await writer.upsertRival(rival)
+
+        let migratedFileURL = try JSONLedgerStore.defaultFileURL(applicationSupportURL: applicationSupportURL)
+        #expect(migratedFileURL.pathComponents.suffix(2) == ["Gammonade", "ledger.json"])
+        #expect(fileManager.fileExists(atPath: migratedFileURL.path))
+        #expect(!fileManager.fileExists(atPath: legacyFileURL.path))
+
+        let reader = try JSONLedgerStore(fileURL: migratedFileURL)
+        #expect(try await reader.loadRivals() == [rival])
+    }
+
+    @Test("default file URL keeps existing Gammonade ledger")
+    func defaultFileURLKeepsExistingGammonadeLedger() async throws {
+        let fileManager = FileManager.default
+        let applicationSupportURL = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let newDirectoryURL = applicationSupportURL.appendingPathComponent("Gammonade", isDirectory: true)
+        let newFileURL = newDirectoryURL.appendingPathComponent("ledger.json")
+        let legacyDirectoryURL = applicationSupportURL.appendingPathComponent("SheshBesh", isDirectory: true)
+        let legacyFileURL = legacyDirectoryURL.appendingPathComponent("ledger.json")
+        defer {
+            try? fileManager.removeItem(at: applicationSupportURL)
+        }
+
+        try fileManager.createDirectory(at: newDirectoryURL, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: legacyDirectoryURL, withIntermediateDirectories: true)
+
+        let gammonadeRival = Rival(displayName: "Mira")
+        let legacyRival = Rival(displayName: "Dan")
+        let newWriter = try JSONLedgerStore(fileURL: newFileURL)
+        try await newWriter.upsertRival(gammonadeRival)
+        let legacyWriter = try JSONLedgerStore(fileURL: legacyFileURL)
+        try await legacyWriter.upsertRival(legacyRival)
+
+        let resolvedFileURL = try JSONLedgerStore.defaultFileURL(applicationSupportURL: applicationSupportURL)
+        let reader = try JSONLedgerStore(fileURL: resolvedFileURL)
+
+        #expect(resolvedFileURL == newFileURL)
+        #expect(try await reader.loadRivals() == [gammonadeRival])
+        #expect(fileManager.fileExists(atPath: legacyFileURL.path))
+    }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shesh Besh
+# Gammonade
 
 An iOS backgammon game repo. The current implementation has a pure Swift rules
 engine plus an early SwiftUI app shell with a Linen & Brass portrait board.
@@ -13,7 +13,7 @@ engine plus an early SwiftUI app shell with a Linen & Brass portrait board.
 ## Repository Layout
 
 ```text
-shesh-besh/
+gammonade/
   Package.swift              # repo-root entry point for swift build/test
   Packages/
     SheshBeshGame/

--- a/SheshBesh.xcodeproj/project.pbxproj
+++ b/SheshBesh.xcodeproj/project.pbxproj
@@ -544,6 +544,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SheshBesh/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "$(BRAND_NAME)";
+				INFOPLIST_KEY_CFBundleName = "$(BRAND_NAME)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -576,6 +577,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = SheshBesh/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "$(BRAND_NAME)";
+				INFOPLIST_KEY_CFBundleName = "$(BRAND_NAME)";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.games";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/SheshBesh.xcodeproj/xcshareddata/xcschemes/SheshBesh.xcscheme
+++ b/SheshBesh.xcodeproj/xcshareddata/xcschemes/SheshBesh.xcscheme
@@ -108,6 +108,7 @@
    </AnalyzeAction>
    <ArchiveAction
       buildConfiguration = "Release"
+      customArchiveName = "Gammonade"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/SheshBesh/Shared/GameCenterSupport.swift
+++ b/SheshBesh/Shared/GameCenterSupport.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SheshBeshLedger
 #endif
 
-private let gcLog = Logger(subsystem: "com.sheshbesh.gamecenter", category: "auth")
+private let gcLog = Logger(subsystem: "com.gammonade.gamecenter", category: "auth")
 
 public enum GameCenterAuthState: Equatable, Sendable {
     case notStarted


### PR DESCRIPTION
Updates product-facing legacy naming to Gammonade while keeping internal SheshBesh targets and bundle IDs stable. Moves the default ledger path to Application Support/Gammonade with one-time migration from the old SheshBesh folder, and covers that migration with tests. Pins archive metadata so Product > Archive produces a Gammonade archive and app bundle name. Also updates the Game Center log namespace and PR screenshot skill wording. Verified with swift test, ./scripts/test.sh, git diff --check, legacy-name sweeps, and a local xcodebuild archive metadata check.