### PR TITLE
fix: Disable repeated reminders

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -6,7 +6,7 @@ public struct BoardView: View {
     private let onBackToRivals: (() -> Void)?
     private let onSendReminder: (@MainActor () async -> Void)?
 
-    @State private var isSendingReminder = false
+    @State private var didSendReminder = false
     @State private var selectedSource: MoveSource?
     @Namespace private var checkerNamespace
 
@@ -118,20 +118,22 @@ public struct BoardView: View {
 
     private func reminderButton(action: @escaping @MainActor () async -> Void) -> some View {
         Button {
-            isSendingReminder = true
+            didSendReminder = true
             Task {
                 await action()
-                isSendingReminder = false
             }
         } label: {
-            Label("Remind", systemImage: "bell.badge")
+            Label(
+                didSendReminder ? "Reminded" : "Remind",
+                systemImage: didSendReminder ? "bell.fill" : "bell.badge"
+            )
                 .font(LinenBrass.uiFont(size: 13, weight: .semibold))
                 .labelStyle(.titleAndIcon)
         }
         .buttonStyle(.bordered)
         .tint(LinenBrass.brass)
         .foregroundStyle(LinenBrass.cream)
-        .disabled(isSendingReminder)
+        .disabled(didSendReminder)
         .accessibilityIdentifier("opponent-turn-remind")
     }
 

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -70,6 +70,11 @@ public struct BoardView: View {
         .onChange(of: viewModel.state.game.phase) { _, _ in
             selectedSource = nil
         }
+        .onChange(of: viewModel.isOpponentTurn) { _, isOpponentTurn in
+            if isOpponentTurn {
+                didSendReminder = false
+            }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Makes the Game Center Remind button sticky-disabled after the first tap so users cannot spam GameKit reminder calls during an opponent turn.
- Updates the button feedback to show "Reminded" with a filled bell icon once tapped.

## Verification
- xcodebuild -project SheshBesh.xcodeproj -scheme SheshBesh -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build