### PR TITLE
Drop redundant "vs <opponent>" header in match view

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -370,7 +370,7 @@ private struct HeaderCard: View {
     let onBackToRivals: (() -> Void)?
 
     var body: some View {
-        HStack(alignment: .center, spacing: -12) {
+        HStack(alignment: .center, spacing: 0) {
             if let onBackToRivals {
                 Button(action: onBackToRivals) {
                     Image(systemName: "chevron.left")
@@ -383,13 +383,6 @@ private struct HeaderCard: View {
                 .accessibilityLabel("Back to rivals")
                 .accessibilityIdentifier("match-back-button")
             }
-
-            Text("vs \(viewModel.opponentName.uppercased())")
-                .font(LinenBrass.uiFont(size: 13, weight: .semibold))
-                .tracking(0.6)
-                .foregroundStyle(LinenBrass.mutedInk)
-                .lineLimit(1)
-                .minimumScaleFactor(0.78)
 
             Spacer(minLength: 10)
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -119,6 +119,22 @@ Deferred items surfaced during /plan-eng-review on 2026-04-23. Each captures wha
 
 ---
 
+## Render the back chevron in board-opening UI test scene
+
+**What:** Pass an `onBackToRivals` stub into the `RootView`/`BoardView` constructed by `AppLaunchConfiguration.UITestScene.boardOpening` so the header's back chevron is rendered in PR screenshots.
+
+**Why:** The board-opening scene currently constructs the board without a back callback, so the chevron is hidden — even though the production path in `RootView` always passes the callback when navigating Rivalries → Match. PR reviewers looking at header screenshots can wrongly conclude the chevron was removed (surfaced in PR #68).
+
+**Pros:** PR screenshots match production fidelity for header changes.
+
+**Cons:** Trivial.
+
+**Context:** `SheshBesh/Shared/AppLaunchConfiguration.swift:53` (the `.boardOpening` case). May need a small adjustment to the test-only `RootView`/`BoardView` initializer wiring to thread a stub callback into this construction path. `HeaderCard` in `SheshBesh/Shared/BoardView.swift:368` is the gated component.
+
+**Depends on / blocked by:** None.
+
+---
+
 ## Full VoiceOver game-play narration (pre-App-Store)
 
 **What:** VoiceOver support for actual backgammon gameplay — board state narration ("opponent has 5 checkers on the 19 point"), legal-move announcement on source tap ("3 legal destinations: 17-point, 15-point, bear off"), turn transitions, dice announcements, cube offer narration. Baseline a11y (44pt touch targets, Dynamic Type, reduce-motion, WCAG AA contrast) is already in V1; this is the next layer.


### PR DESCRIPTION
## Summary
- The opponent name already appears in the score column dot row and again in the pip strip below; the `vs <OPPONENT>` breadcrumb on the left of `HeaderCard` was a third copy in a small vertical span. This drops it.
- `HStack` spacing in `HeaderCard` goes from `-12` to `0` since the negative spacing existed only to tighten the back button against the now-deleted text.

## Screenshot

Before / after of the in-game header (board-opening scene, "Medium AI" rival): the top-left `vs MEDIUM AI` line is gone; the score column on the right is unchanged and still labels each dot row, and the pip strip below still names whose pip count is whose.

`.context/pr-screenshots/board-opening-pre-roll.png`

## Test plan
- [x] `xcodebuild build` passes
- [x] `SheshBeshUITests/PRScreenshotsTests/testCapture_BoardOpening` passes (existing `header-score` accessibility assertion still holds)
- [ ] Eyeball the simulator with a long opponent name to confirm the score column still right-aligns cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)