### PR TITLE
Add left-edge swipe gesture to navigate back from match board

### DIFF
--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -75,6 +75,19 @@ public struct BoardView: View {
                 didSendReminder = false
             }
         }
+        .gesture(backSwipeGesture)
+    }
+
+    private var backSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 18, coordinateSpace: .local)
+            .onEnded { value in
+                guard let onBackToRivals else { return }
+                let startsAtLeftEdge = value.startLocation.x <= 24
+                let mostlyHorizontal = abs(value.translation.height) < 44
+                let swipedRightFarEnough = value.translation.width > 90
+                guard startsAtLeftEdge, mostlyHorizontal, swipedRightFarEnough else { return }
+                onBackToRivals()
+            }
     }
 
     @ViewBuilder


### PR DESCRIPTION
### Motivation
- Allow users to swipe from the left edge to return to the rivals/main screen instead of forcing them to tap the top-left caret, improving navigation ergonomics on touch devices.

### Description
- Add a `backSwipeGesture` to `SheshBesh/Shared/BoardView.swift` and attach it via `.gesture(backSwipeGesture)` to the view container, where the gesture is a `DragGesture` that calls `onBackToRivals()` when the drag starts near the left edge, is mostly horizontal, and moves far enough to the right.

### Testing
- Ran the project test script `./scripts/test.sh`, which failed in this environment due to a toolchain mismatch (`Swift tools 6.2.0` required vs installed `6.1.3`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f1fe75d1e8832ab49064949d5b7216)