### PR TITLE
Fix board point labels for player perspective

### DIFF
--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/Board.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/Board.swift
@@ -168,7 +168,7 @@ public struct Board: Codable, Equatable, Hashable, Sendable {
                 self.point(PointID(rawValue: rawValue)!).owner != .white
             }
         case .black:
-            let exactDie = 25 - point.rawValue
+            let exactDie = point.perspectiveValue(for: player)
             if exactDie == die { return true }
             guard die > exactDie else { return false }
             let fartherPoints = 19..<(point.rawValue)

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/MoveNotation.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/MoveNotation.swift
@@ -58,9 +58,6 @@ public enum MoveNotation {
     }
 
     private static func pointNumber(_ point: PointID, from perspective: Player) -> Int {
-        switch perspective {
-        case .white: return point.rawValue
-        case .black: return 25 - point.rawValue
-        }
+        point.perspectiveValue(for: perspective)
     }
 }

--- a/Packages/SheshBeshGame/Sources/SheshBeshGame/Player.swift
+++ b/Packages/SheshBeshGame/Sources/SheshBeshGame/Player.swift
@@ -45,6 +45,15 @@ public struct PointID: RawRepresentable, Codable, Comparable, Equatable, Hashabl
         self.rawValue = rawValue
     }
 
+    public func perspectiveValue(for player: Player) -> Int {
+        switch player {
+        case .white:
+            rawValue
+        case .black:
+            25 - rawValue
+        }
+    }
+
     public static func < (lhs: PointID, rhs: PointID) -> Bool {
         lhs.rawValue < rhs.rawValue
     }

--- a/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
+++ b/Packages/SheshBeshGame/Tests/SheshBeshGameTests/BoardTests.swift
@@ -11,6 +11,14 @@ struct BoardTests {
         #expect(PointID(rawValue: -1) == nil)
     }
 
+    @Test("Point IDs expose player-perspective numbering")
+    func pointIDPerspectiveValueUsesPlayerView() {
+        let point = point(18)
+
+        #expect(point.perspectiveValue(for: .white) == 18)
+        #expect(point.perspectiveValue(for: .black) == 7)
+    }
+
     @Test("Initial board has standard checker placement")
     func initialBoardPlacement() {
         let board = Board.initial()

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -713,7 +713,7 @@ private struct PointCell: View {
 
                 VStack {
                     if pointsDown { Spacer(minLength: 0) }
-                    Text("\(pointID.rawValue)")
+                    Text("\(displayPointNumber)")
                         .font(LinenBrass.uiFont(size: 9, weight: .medium))
                         .foregroundStyle(LinenBrass.coffee.opacity(0.64))
                         .lineLimit(1)
@@ -748,11 +748,15 @@ private struct PointCell: View {
 
     private var accessibilityLabel: String {
         guard let owner = point.owner else {
-            return "Point \(pointID.rawValue), empty\(stateSuffix)"
+            return "Point \(displayPointNumber), empty\(stateSuffix)"
         }
         let player = owner == localPlayer ? "your" : "opponent"
         let checkerWord = point.count == 1 ? "checker" : "checkers"
-        return "Point \(pointID.rawValue), \(point.count) \(player) \(checkerWord)\(stateSuffix)"
+        return "Point \(displayPointNumber), \(point.count) \(player) \(checkerWord)\(stateSuffix)"
+    }
+
+    private var displayPointNumber: Int {
+        pointID.perspectiveValue(for: localPlayer)
     }
 
     private var stateSuffix: String {

--- a/SheshBesh/Shared/MatchViewModel.swift
+++ b/SheshBesh/Shared/MatchViewModel.swift
@@ -778,12 +778,12 @@ public final class MatchViewModel {
         var black = 0
 
         for (offset, point) in board.points.enumerated() {
-            let rawPoint = offset + 1
+            guard let pointID = PointID(rawValue: offset + 1) else { continue }
             switch point.owner {
             case .white:
-                white += rawPoint * point.count
+                white += pointID.perspectiveValue(for: .white) * point.count
             case .black:
-                black += (25 - rawPoint) * point.count
+                black += pointID.perspectiveValue(for: .black) * point.count
             case nil:
                 continue
             }
@@ -1057,12 +1057,7 @@ public struct LocalAIOpponent: Sendable {
     }
 
     private func pips(from point: PointID, for player: Player) -> Int {
-        switch player {
-        case .white:
-            return point.rawValue
-        case .black:
-            return 25 - point.rawValue
-        }
+        point.perspectiveValue(for: player)
     }
 
     private func clampedRandomIndex(upperBound: Int) -> Int {


### PR DESCRIPTION
## Summary
- Render visible board point labels from the local player's perspective.
- Match VoiceOver point labels to the same displayed board numbering.
- Keep raw point IDs unchanged for board state, taps, and test identifiers.

## Tests
- swift test