### PR TITLE
Move incoming double offers into the bottom action bar

### DIFF
--- a/SheshBesh/Shared/AppLaunchConfiguration.swift
+++ b/SheshBesh/Shared/AppLaunchConfiguration.swift
@@ -44,6 +44,7 @@ public enum AppLaunchConfiguration {
     public enum UITestScene: String, CaseIterable {
         case boardOpening = "board-opening"
         case boardOpponentSkip = "board-opponent-skip"
+        case boardDoubleOffer = "board-double-offer"
         case rivalriesHome = "rivalries-home"
         case matchEndYouWon = "match-end-you-won"
         case matchEndRivalWon = "match-end-rival-won"
@@ -63,6 +64,9 @@ public enum AppLaunchConfiguration {
 
             case .boardOpponentSkip:
                 return RootView(viewModel: makeOpponentSkipViewModel())
+
+            case .boardDoubleOffer:
+                return RootView(viewModel: makeDoubleOfferViewModel())
 
             case .rivalriesHome:
                 return RootView(coordinator: seededRootLedgerCoordinator())
@@ -119,6 +123,29 @@ public enum AppLaunchConfiguration {
             engine: MatchEngine(diceRoller: ScriptedDiceRoller([5, 3])),
             config: .tournament(targetScore: 7),
             initialState: initialState,
+            opponentDelay: {}
+        )
+    }
+
+    @MainActor
+    private static func makeDoubleOfferViewModel() -> MatchViewModel {
+        let initialState = MatchState(
+            config: .tournament(targetScore: 7),
+            game: GameState(
+                phase: .awaitingCubeResponse(
+                    CubeOffer(
+                        offeredBy: .black,
+                        proposedValue: 2,
+                        previousCubeValue: 1
+                    )
+                )
+            )
+        )
+
+        return MatchViewModel(
+            config: .tournament(targetScore: 7),
+            initialState: initialState,
+            isOpponentAutoplayEnabled: false,
             opponentDelay: {}
         )
     }

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -1419,18 +1419,18 @@ private struct ActionBar: View {
                 localAutoplayButton
 
             case .awaitingCubeResponse(let offer) where offer.offeredBy.opponent == viewModel.localPlayer:
-                PrimaryActionButton(
-                    title: "Take \(offer.proposedValue)",
-                    accessibilityIdentifier: "action-take-double"
-                ) {
-                    viewModel.takeDoubleIfAllowed()
-                    onAction()
-                }
                 SecondaryActionButton(
                     title: "Drop",
                     accessibilityIdentifier: "action-drop-double"
                 ) {
                     viewModel.dropDoubleIfAllowed()
+                    onAction()
+                }
+                PrimaryActionButton(
+                    title: "Take \(offer.proposedValue)",
+                    accessibilityIdentifier: "action-take-double"
+                ) {
+                    viewModel.takeDoubleIfAllowed()
                     onAction()
                 }
 

--- a/SheshBesh/Shared/BoardView.swift
+++ b/SheshBesh/Shared/BoardView.swift
@@ -164,7 +164,7 @@ public struct BoardView: View {
     }
 
     private var showsActionBar: Bool {
-        !viewModel.isOpponentTurn && viewModel.doubleOfferForLocalPlayer == nil
+        !viewModel.isOpponentTurn
     }
 
     private func handlePointTap(_ pointID: PointID) {
@@ -205,128 +205,6 @@ public struct BoardView: View {
         if viewModel.applyMove(from: selectedSource, to: .off) {
             self.selectedSource = nil
         }
-    }
-}
-
-public struct DoubleOfferSheet: View {
-    public let viewModel: MatchViewModel
-    private let onBackToRivals: (() -> Void)?
-
-    public init(
-        viewModel: MatchViewModel,
-        onBackToRivals: (() -> Void)? = nil
-    ) {
-        self.viewModel = viewModel
-        self.onBackToRivals = onBackToRivals
-    }
-
-    public var body: some View {
-        ZStack {
-            BoardView(
-                viewModel: viewModel,
-                onBackToRivals: onBackToRivals
-            )
-
-            LinenBrass.ink.opacity(0.42)
-                .ignoresSafeArea()
-                .allowsHitTesting(false)
-
-            if let offer = viewModel.doubleOfferForLocalPlayer {
-                offerCard(offer)
-                    .padding(.horizontal, 24)
-            }
-        }
-    }
-
-    private func offerCard(_ offer: CubeOffer) -> some View {
-        VStack(spacing: 18) {
-            CubeView(cube: CubeState(value: offer.proposedValue, owner: viewModel.localPlayer.opponent), localPlayer: viewModel.localPlayer)
-                .frame(width: 54, height: 54)
-
-            VStack(spacing: 6) {
-                Text("\(viewModel.opponentName) is offering a double to \(offer.proposedValue)")
-                    .font(LinenBrass.displayFont(size: 24, weight: .bold))
-                    .foregroundStyle(LinenBrass.ink)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(3)
-                    .minimumScaleFactor(0.78)
-                    .accessibilityIdentifier("double-offer-title")
-
-                Text("The board is frozen until you take or drop.")
-                    .font(LinenBrass.uiFont(size: 14, weight: .medium))
-                    .foregroundStyle(LinenBrass.mutedInk)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(2)
-            }
-
-            VStack(spacing: 8) {
-                consequenceRow(
-                    title: "Take",
-                    detail: "Play on with the cube at \(offer.proposedValue)."
-                )
-                consequenceRow(
-                    title: "Drop",
-                    detail: "\(viewModel.opponentName) scores \(pointsText(offer.previousCubeValue))."
-                )
-            }
-
-            HStack(spacing: 12) {
-                Button {
-                    viewModel.dropDoubleIfAllowed()
-                } label: {
-                    Text("Drop")
-                        .font(LinenBrass.uiFont(size: 17, weight: .semibold))
-                        .frame(maxWidth: .infinity, minHeight: 48)
-                }
-                .buttonStyle(LinenButtonStyle(kind: .secondary))
-                .accessibilityIdentifier("action-drop-double")
-
-                Button {
-                    viewModel.takeDoubleIfAllowed()
-                } label: {
-                    Text("Take")
-                        .font(LinenBrass.uiFont(size: 17, weight: .semibold))
-                        .frame(maxWidth: .infinity, minHeight: 48)
-                }
-                .buttonStyle(LinenButtonStyle(kind: .primary))
-                .accessibilityIdentifier("action-take-double")
-            }
-        }
-        .padding(22)
-        .frame(maxWidth: 360)
-        .background(
-            RoundedRectangle(cornerRadius: 7)
-                .fill(LinenBrass.cream)
-                .shadow(color: .black.opacity(0.28), radius: 14, y: 7)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 7)
-                .stroke(LinenBrass.brass.opacity(0.72), lineWidth: 1)
-        )
-    }
-
-    private func consequenceRow(title: String, detail: String) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
-            Text(title)
-                .font(LinenBrass.uiFont(size: 14, weight: .bold))
-                .foregroundStyle(LinenBrass.ink)
-                .frame(width: 44, alignment: .leading)
-
-            Text(detail)
-                .font(LinenBrass.uiFont(size: 14, weight: .medium))
-                .foregroundStyle(LinenBrass.mutedInk)
-                .lineLimit(2)
-                .minimumScaleFactor(0.8)
-
-            Spacer(minLength: 0)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 9)
-        .background(LinenBrass.linen, in: RoundedRectangle(cornerRadius: 6))
-    }
-
-    private func pointsText(_ value: Int) -> String {
-        value == 1 ? "1 point" : "\(value) points"
     }
 }
 
@@ -1541,12 +1419,18 @@ private struct ActionBar: View {
                 localAutoplayButton
 
             case .awaitingCubeResponse(let offer) where offer.offeredBy.opponent == viewModel.localPlayer:
-                PrimaryActionButton(title: "Take \(offer.proposedValue)") {
-                    viewModel.send(.takeDouble(viewModel.localPlayer))
+                PrimaryActionButton(
+                    title: "Take \(offer.proposedValue)",
+                    accessibilityIdentifier: "action-take-double"
+                ) {
+                    viewModel.takeDoubleIfAllowed()
                     onAction()
                 }
-                SecondaryActionButton(title: "Drop") {
-                    viewModel.send(.dropDouble(viewModel.localPlayer))
+                SecondaryActionButton(
+                    title: "Drop",
+                    accessibilityIdentifier: "action-drop-double"
+                ) {
+                    viewModel.dropDoubleIfAllowed()
                     onAction()
                 }
 
@@ -1678,6 +1562,7 @@ private struct PrimaryActionButton: View {
 
 private struct SecondaryActionButton: View {
     let title: String
+    var accessibilityIdentifier: String?
     let action: () -> Void
 
     var body: some View {
@@ -1689,7 +1574,7 @@ private struct SecondaryActionButton: View {
                 .frame(maxWidth: .infinity, minHeight: 48)
         }
         .buttonStyle(LinenButtonStyle(kind: .secondary))
-        .accessibilityIdentifier(actionAccessibilityIdentifier(for: title))
+        .accessibilityIdentifier(accessibilityIdentifier ?? actionAccessibilityIdentifier(for: title))
     }
 }
 

--- a/SheshBesh/Shared/RootView.swift
+++ b/SheshBesh/Shared/RootView.swift
@@ -139,15 +139,11 @@ public struct RootView: View {
         onBackToRivals: (() -> Void)? = nil,
         onSendReminder: (@MainActor () async -> Void)? = nil
     ) -> some View {
-        if viewModel.doubleOfferForLocalPlayer != nil {
-            DoubleOfferSheet(viewModel: viewModel, onBackToRivals: onBackToRivals)
-        } else {
-            BoardView(
-                viewModel: viewModel,
-                onBackToRivals: onBackToRivals,
-                onSendReminder: onSendReminder
-            )
-        }
+        BoardView(
+            viewModel: viewModel,
+            onBackToRivals: onBackToRivals,
+            onSendReminder: onSendReminder
+        )
     }
 
     private func openMatch(_ match: ActiveMatch) {

--- a/SheshBeshUITests/PRScreenshotsTests.swift
+++ b/SheshBeshUITests/PRScreenshotsTests.swift
@@ -50,9 +50,9 @@ final class PRScreenshotsTests: XCTestCase {
         app.launch()
 
         // The AI rolls into a closed-out home and auto-skips. Wait for the
-        // local roll-dice button so we know the skip has finished and the
+        // local roll button so we know the skip has finished and the
         // tray's previous-roll slot is rendered.
-        XCTAssertTrue(app.buttons["action-roll-dice"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["action-roll"].waitForExistence(timeout: 5))
         attachScreenshot(named: "board-opponent-skip")
     }
 

--- a/SheshBeshUITests/SheshBeshUITests.swift
+++ b/SheshBeshUITests/SheshBeshUITests.swift
@@ -45,6 +45,37 @@ final class SheshBeshUITests: XCTestCase {
     }
 
     @MainActor
+    func testIncomingDoubleOfferUsesBottomActionBar() throws {
+        let app = doubleOfferApp()
+        app.launch()
+
+        XCTAssertTrue(element("board", in: app).waitForExistence(timeout: 5))
+        XCTAssertTrue(element("point-24", in: app).exists)
+        XCTAssertFalse(element("double-offer-title", in: app).exists)
+        XCTAssertTrue(app.buttons["action-take-double"].exists)
+        XCTAssertTrue(app.buttons["action-drop-double"].exists)
+
+        app.buttons["action-take-double"].tap()
+
+        XCTAssertTrue(element("opponent-turn-status", in: app).waitForExistence(timeout: 2))
+        XCTAssertFalse(app.buttons["action-take-double"].exists)
+        XCTAssertFalse(app.buttons["action-drop-double"].exists)
+    }
+
+    @MainActor
+    func testIncomingDoubleDropResolvesOffer() throws {
+        let app = doubleOfferApp()
+        app.launch()
+
+        XCTAssertTrue(app.buttons["action-drop-double"].waitForExistence(timeout: 5))
+        app.buttons["action-drop-double"].tap()
+
+        XCTAssertTrue(app.buttons["action-next-game"].waitForExistence(timeout: 2))
+        XCTAssertFalse(app.buttons["action-take-double"].exists)
+        XCTAssertFalse(app.buttons["action-drop-double"].exists)
+    }
+
+    @MainActor
     func testRootRivalryButtonsDoNotRenderSystemBlueIcons() throws {
         let app = rootLedgerApp()
         app.launch()
@@ -88,6 +119,13 @@ final class SheshBeshUITests: XCTestCase {
             "-uiTestDice",
             "6,1,6,1",
         ]
+        return app
+    }
+
+    @MainActor
+    private func doubleOfferApp() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uiTestScene", "board-double-offer"]
         return app
     }
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -89,7 +89,7 @@ Deferred items surfaced during /plan-eng-review on 2026-04-23. Each captures wha
 **Status:** Completed on 2026-04-26. Approved manifest:
 `~/.gstack/projects/bjabes-shesh-besh/designs/secondary-screens-20260424/approved.json`.
 
-**What:** Approved design directions exist for the four secondary V1 screens. Screens: HomeView (0-rival empty, 1-rival hero, multi-rival scrollable), Opponent-Turn read-only board, DoubleOfferSheet ("Dan is offering a double to 4 - Take/Drop"), Match-End sheet overlay.
+**What:** Approved design directions exist for the four secondary V1 screens. Screens: HomeView (0-rival empty, 1-rival hero, multi-rival scrollable), Opponent-Turn read-only board, incoming double response ("Dan is offering a double to 4 - Take/Drop"), Match-End sheet overlay.
 
 **Why:** BoardView has a locked visual identity (Linen & Brass) but half the V1 experience lives on the other four screens. Without mockups, engineering ships placeholders and the visual language fragments across states.
 


### PR DESCRIPTION
## Summary
- Replace the modal double-offer sheet with the existing bottom `ActionBar` flow.
- Keep the board fully visible and read-only while the local player decides Take or Drop.
- Add a deterministic UI test scene for incoming double offers and update screenshot/test fixtures to match current button identifiers.
- Remove stale `DoubleOfferSheet` wording from the completed TODO note.

## Testing
- `swift test` passed.
- Full UI test suite passed via the Xcode UI test script, including the new incoming-double coverage and screenshot scenes.